### PR TITLE
Replace the call to get_api_by_name

### DIFF
--- a/src/rpc/http_api.cpp
+++ b/src/rpc/http_api.cpp
@@ -17,9 +17,7 @@ http_api_connection::http_api_connection()
       api_id_type api_id;
       if( args[0].is_string() )
       {
-         variants subargs;
-         subargs.push_back( args[0] );
-         variant subresult = this->receive_call( 1, "get_api_by_name", subargs );
+         variant subresult = this->receive_call( 1, args[0].as_string() );
          api_id = subresult.as_uint64();
       }
       else

--- a/src/rpc/websocket_api.cpp
+++ b/src/rpc/websocket_api.cpp
@@ -16,9 +16,7 @@ websocket_api_connection::websocket_api_connection( fc::http::websocket_connecti
       api_id_type api_id;
       if( args[0].is_string() )
       {
-         variants subargs;
-         subargs.push_back( args[0] );
-         variant subresult = this->receive_call( 1, "get_api_by_name", subargs );
+         variant subresult = this->receive_call( 1, args[0].as_string() );
          api_id = subresult.as_uint64();
       }
       else


### PR DESCRIPTION
Replace the call to get_api_by_name with a direct call to the functions that return fc::api<> in the login_api.

If the call to any of this functions succeed (because they where previously enabled),
the api will auto-register itself in the websocket_api_connection/http_api_connection and will return an api_id_type.