### PR TITLE
In order to pass compile in vs2013, fixed:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,6 @@ set( fc_sources
      src/crypto/dh.cpp
      src/crypto/blowfish.cpp
      src/crypto/elliptic_common.cpp
-     src/crypto/equihash.cpp
      ${ECC_REST}
      src/crypto/elliptic_${ECC_IMPL}.cpp
      src/crypto/rand.cpp
@@ -251,7 +250,6 @@ list(APPEND sources "${CMAKE_CURRENT_BINARY_DIR}/git_revision.cpp")
 list(APPEND sources ${fc_headers})
 
 add_subdirectory( vendor/websocketpp EXCLUDE_FROM_ALL )
-add_subdirectory( vendor/equihash )
 
 setup_library( fc SOURCES ${sources} LIBRARY_TYPE STATIC )
 install( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION include )
@@ -373,14 +371,13 @@ target_include_directories(fc
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/boost_1.51/include
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/cyoencode-1.0.2/src
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/secp256k1-zkp
-    ${CMAKE_CURRENT_SOURCE_DIR}/vendor/equihash
   )
 
 #target_link_libraries( fc PUBLIC ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} ${RPCRT4} ${CMAKE_DL_LIBS} ${rt_library} ${ECC_LIB} )
 IF(NOT WIN32)
   set(LINK_USR_LOCAL_LIB -L/usr/local/lib)
 ENDIF()
-target_link_libraries( fc PUBLIC ${LINK_USR_LOCAL_LIB} equihash ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} ${RPCRT4} ${CMAKE_DL_LIBS} ${rt_library} ${readline_libraries} ${ECC_LIB} )
+target_link_libraries( fc PUBLIC ${LINK_USR_LOCAL_LIB} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${PLATFORM_SPECIFIC_LIBS} ${RPCRT4} ${CMAKE_DL_LIBS} ${rt_library} ${readline_libraries} ${ECC_LIB} )
 
 if(MSVC)
   set_source_files_properties( src/network/http/websocket.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
@@ -396,7 +393,6 @@ ENDIF(MSVC)
 ENDIF()
 
 include_directories( vendor/websocketpp )
-include_directories( vendor/equihash )
 
 add_subdirectory(tests)
 

--- a/include/fc/container/flat_fwd.hpp
+++ b/include/fc/container/flat_fwd.hpp
@@ -16,8 +16,8 @@ namespace fc {
        void unpack( Stream& s, flat_set<T>& value );
        template<typename Stream, typename K, typename... V>
        void pack( Stream& s, const flat_map<K,V...>& value );
-       template<typename Stream, typename K, typename... V>
-       void unpack( Stream& s, flat_map<K,V...>& value ) ;
+       template<typename Stream, typename K, typename V, typename... A>
+       void unpack(Stream& s, flat_map<K, V, A...>& value);
 
 
        template<typename Stream, typename T, typename A>

--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -90,8 +90,8 @@ namespace fc
 
    template<typename K, typename... T>
    void to_variant( const fc::flat_map<K,T...>& var,  variant& vo );
-   template<typename K, typename... T>
-   void from_variant( const variant& var, fc::flat_map<K,T...>& vo );
+   template<typename K, typename T, typename... A>
+   void from_variant(const variant& var, flat_map<K, T, A...>& vo);
 
    template<typename K, typename T>
    void to_variant( const std::map<K,T>& var,  variant& vo );


### PR DESCRIPTION
1.removed equihash from the CMakeLists.txt.
2.fix the inconsistencies of the template function‘s declaration and definition of "from_variant" ,"unpack"  that processes flat_map.
Signed-off-by: kinglaw <58291@qq.com>