### PR TITLE
Fix compile error

### DIFF
--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -15,7 +15,7 @@ namespace fc {
   class exception;
   namespace ip { class address; }
 
-  template<typename T> class get_typename{};
+  template<typename... T> struct get_typename;
   template<> struct get_typename<int32_t>  { static const char* name()  { return "int32_t";  } };
   template<> struct get_typename<int64_t>  { static const char* name()  { return "int64_t";  } };
   template<> struct get_typename<int16_t>  { static const char* name()  { return "int16_t";  } };

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -382,5 +382,5 @@ struct visitor {
       s.visit( to_static_variant(ar[1]) );
    }
 
-  template<typename... T> struct get_typename<T...>  { static const char* name()   { return typeid(static_variant<T...>).name();   } };
+  template<typename... T> struct get_typename  { static const char* name()   { return typeid(static_variant<T...>).name();   } };
 } // namespace fc


### PR DESCRIPTION
Compile failed with gcc 7.2 under archlinux due to template part specialization, I googleed a fix from eos.
https://github.com/EOSIO/eos/pull/164/files
and it works finally.
