### PR TITLE
correctly handle list of methods

### DIFF
--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -119,27 +119,30 @@ void cli::run()
  */
 static char *my_rl_complete(char *token, int *match)
 {
-    int matchlen = 0;
-    int count = 0;
-    std::string method_name;
+	int matchlen = 0;
+	int count = 0;
+	std::string method_name;
 
-    auto& cmd = cli_commands();
-    int partlen = strlen (token); /* Part of token */
-    for (std::string it : cmd) {
-        if (!strncmp ( it.c_str(), token, partlen)) {
-            method_name = it;
-            matchlen = partlen;
-            count ++;
-        }
-    }
+	auto& cmd = cli_commands();
+	int partlen = strlen (token); /* Part of token */
+	for (const std::string it : cmd)
+	{
+		if (it.compare(0, partlen, token) == 0)
+		{
+			method_name = it;
+			matchlen = partlen;
+			count ++;
+		}
+	}
 
-    if (count == 1) {
-        *match = 1;
-        method_name += " ";
-        return strdup (method_name.c_str() + matchlen);
-    }
+	if (count == 1)
+	{
+		*match = 1;
+		method_name += " ";
+		return strdup (method_name.c_str() + matchlen);
+	}
 
-    return NULL;
+	return NULL;
 }
 
 /***

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -216,10 +216,20 @@ void cli::getline( const fc::string& prompt, fc::string& line)
          line_read = readline(prompt.c_str());
          if( line_read == nullptr )
             FC_THROW_EXCEPTION( fc::eof_exception, "" );
-         if( *line_read )
-            add_history(line_read);
          line = line_read;
-         free(line_read);
+         if (*line_read)
+         {
+            try
+            {
+               add_history(line_read);
+               free(line_read);
+            }
+            catch(...)
+            {
+               free(line_read);
+               throw;
+            }
+         }
       }).wait();
    }
    else

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -221,13 +221,13 @@ void cli::getline( const fc::string& prompt, fc::string& line)
          {
             if (*line_read)
                add_history(line_read);
-            free(line_read);
          }
          catch(...)
          {
             free(line_read);
             throw;
          }
+         free(line_read);
       }).wait();
    }
    else

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -125,7 +125,7 @@ static char *my_rl_complete(char *token, int *match)
    auto& cmd = cli_commands();
    int partlen = strlen (token); /* Part of token */
 
-   for (const std::string it : cmd)
+   for (const std::string& it : cmd)
    {
       if (it.compare(0, partlen, token) == 0)
       {
@@ -172,7 +172,7 @@ static int cli_completion(char *token, char ***array)
 
    int partlen = strlen(token);
 
-   for (const std::string it : cmd)
+   for (const std::string& it : cmd)
    {
       if ( it.compare(0, partlen, token) == 0)
       {

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -119,30 +119,30 @@ void cli::run()
  */
 static char *my_rl_complete(char *token, int *match)
 {
-	int matchlen = 0;
-	int count = 0;
-	std::string method_name;
+   int matchlen = 0;
+   int count = 0;
+   std::string method_name;
 
-	auto& cmd = cli_commands();
-	int partlen = strlen (token); /* Part of token */
-	for (const std::string it : cmd)
-	{
-		if (it.compare(0, partlen, token) == 0)
-		{
-			method_name = it;
-			matchlen = partlen;
-			count ++;
-		}
-	}
+   auto& cmd = cli_commands();
+   int partlen = strlen (token); /* Part of token */
+   for (const std::string it : cmd)
+   {
+      if (it.compare(0, partlen, token) == 0)
+      {
+         method_name = it;
+         matchlen = partlen;
+         count ++;
+      }
+   }
 
-	if (count == 1)
-	{
-		*match = 1;
-		method_name += " ";
-		return strdup (method_name.c_str() + matchlen);
-	}
+   if (count == 1)
+   {
+      *match = 1;
+      method_name += " ";
+      return strdup (method_name.c_str() + matchlen);
+   }
 
-	return NULL;
+   return NULL;
 }
 
 /***

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -217,18 +217,16 @@ void cli::getline( const fc::string& prompt, fc::string& line)
          if( line_read == nullptr )
             FC_THROW_EXCEPTION( fc::eof_exception, "" );
          line = line_read;
-         if (*line_read)
+         try
          {
-            try
-            {
+            if (*line_read)
                add_history(line_read);
-               free(line_read);
-            }
-            catch(...)
-            {
-               free(line_read);
-               throw;
-            }
+            free(line_read);
+         }
+         catch(...)
+         {
+            free(line_read);
+            throw;
          }
       }).wait();
    }

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -114,20 +114,20 @@ void cli::run()
 /****
  * @brief loop through list of commands, attempting to find a match
  * @param token what the user typed
- * @param match
- * @returns the full name of the command or NULL if no matches found
+ * @param match sets to 1 if only 1 match was found
+ * @returns the remaining letters of the name of the command or NULL if 1 match not found
  */
 static char *my_rl_complete(char *token, int *match)
 {
     int matchlen = 0;
     int count = 0;
-    const char* method_name;
+    std::string method_name;
 
     auto& cmd = cli_commands();
     int partlen = strlen (token); /* Part of token */
-    for (auto it : cmd) {
-    	if (!strncmp (it.c_str(), token, partlen)) {
-    		method_name = it.c_str();
+    for (std::string it : cmd) {
+    	if (!strncmp ( it.c_str(), token, partlen)) {
+    		method_name = it;
     		matchlen = partlen;
     		count ++;
     	}
@@ -135,7 +135,7 @@ static char *my_rl_complete(char *token, int *match)
 
     if (count == 1) {
     	*match = 1;
-    	return strdup (method_name + matchlen);
+    	return strdup (method_name.c_str() + matchlen);
     }
 
     return NULL;

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -126,16 +126,17 @@ static char *my_rl_complete(char *token, int *match)
     auto& cmd = cli_commands();
     int partlen = strlen (token); /* Part of token */
     for (std::string it : cmd) {
-    	if (!strncmp ( it.c_str(), token, partlen)) {
-    		method_name = it;
-    		matchlen = partlen;
-    		count ++;
-    	}
+        if (!strncmp ( it.c_str(), token, partlen)) {
+            method_name = it;
+            matchlen = partlen;
+            count ++;
+        }
     }
 
     if (count == 1) {
-    	*match = 1;
-    	return strdup (method_name.c_str() + matchlen);
+        *match = 1;
+        method_name += " ";
+        return strdup (method_name.c_str() + matchlen);
     }
 
     return NULL;

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -153,22 +153,22 @@ static char *my_rl_complete(char *token, int *match)
  */
 static int cli_completion(char *token, char ***av)
 {
-    int num, total = 0;
-    char **copy;
+   int num, total = 0;
+   char **copy;
 
-    auto& cmd = cli_commands();
-    num = cmd.size();
+   auto& cmd = cli_commands();
+   num = cmd.size();
 
-    copy = (char **) malloc (num * sizeof(char *));
-    for (auto it : cmd) {
-    	if (!strncmp (it.c_str(), token, strlen (token))) {
-    		copy[total] = strdup ( it.c_str() );
-    		total ++;
-    	}
-    }
-    *av = copy;
+   copy = (char **) malloc (num * sizeof(char *));
+   for (auto it : cmd) {
+      if (!strncmp (it.c_str(), token, strlen (token))) {
+         copy[total] = strdup ( it.c_str() );
+         total ++;
+      }
+   }
+   *av = copy;
 
-    return total;
+   return total;
 }
 
 /***


### PR DESCRIPTION
Pressing the tab key for command completion was providing erroneous method names if there was only 1 match.