### PR TITLE
Update websocketpp submodule to a forked and patched version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
     url = https://github.com/bitshares/secp256k1-zkp.git
 [submodule "vendor/websocketpp"]
     path = vendor/websocketpp
-    url = https://github.com/zaphoyd/websocketpp.git
+    url = https://github.com/bitshares/websocketpp.git
 [submodule "vendor/editline"]
     path = vendor/editline
     url = https://github.com/troglobit/editline.git


### PR DESCRIPTION
Including patches for #7 and https://github.com/bitshares/bitshares-core/issues/701.

After merged, need to run `git submodule sync --recursive` to update local repository. **This should be mentioned in release notes.**