### PR TITLE
Fix class serialization

### DIFF
--- a/include/fc/crypto/aes.hpp
+++ b/include/fc/crypto/aes.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <fc/io/raw_fwd.hpp>
 #include <fc/crypto/sha512.hpp>
 #include <fc/crypto/sha256.hpp>
 #include <fc/uint128.hpp>

--- a/include/fc/crypto/ripemd160.hpp
+++ b/include/fc/crypto/ripemd160.hpp
@@ -71,6 +71,20 @@ class ripemd160
     uint32_t _hash[5];
 };
 
+namespace raw {
+
+   template<typename T>
+   inline void pack( T& ds, const ripemd160& ep, uint32_t _max_depth ) {
+      ds << ep;
+   }
+
+   template<typename T>
+   inline void unpack( T& ds, ripemd160& ep, uint32_t _max_depth ) {
+      ds >> ep;
+   }
+
+}
+
   class variant;
   void to_variant( const ripemd160& bi, variant& v );
   void from_variant( const variant& v, ripemd160& bi );

--- a/include/fc/crypto/sha224.hpp
+++ b/include/fc/crypto/sha224.hpp
@@ -70,6 +70,20 @@ class sha224
     uint32_t _hash[7]; 
 };
 
+namespace raw {
+
+   template<typename T>
+   inline void pack( T& ds, const sha224& ep, uint32_t _max_depth ) {
+      ds << ep;
+   }
+
+   template<typename T>
+   inline void unpack( T& ds, sha224& ep, uint32_t _max_depth ) {
+      ds >> ep;
+   }
+
+}
+
   class variant;
   void to_variant( const sha224& bi, variant& v );
   void from_variant( const variant& v, sha224& bi );

--- a/include/fc/crypto/sha256.hpp
+++ b/include/fc/crypto/sha256.hpp
@@ -98,6 +98,20 @@ class sha256
     uint64_t _hash[4];
 };
 
+namespace raw {
+
+   template<typename T>
+   inline void pack( T& ds, const sha256& ep, uint32_t _max_depth ) {
+      ds << ep;
+   }
+
+   template<typename T>
+   inline void unpack( T& ds, sha256& ep, uint32_t _max_depth ) {
+      ds >> ep;
+   }
+
+}
+
   typedef sha256 uint256;
 
   class variant;

--- a/include/fc/crypto/sha512.hpp
+++ b/include/fc/crypto/sha512.hpp
@@ -66,6 +66,20 @@ class sha512
     uint64_t _hash[8]; 
 };
 
+namespace raw {
+
+   template<typename T>
+   inline void pack( T& ds, const sha512& ep, uint32_t _max_depth ) {
+      ds << ep;
+   }
+
+   template<typename T>
+   inline void unpack( T& ds, sha512& ep, uint32_t _max_depth ) {
+      ds >> ep;
+   }
+
+}
+
   typedef fc::sha512 uint512;
 
   class variant;

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -351,19 +351,10 @@ namespace fc {
           const uint32_t max_depth;
       };
 
+      // Default pack/unpack functions for classes (if_class<fc::true_type>) are removed due to recursion issue.
+      // Classes should implement pack/unpack functions explicitly.
       template<typename IsClass=fc::true_type>
-      struct if_class{
-        template<typename Stream, typename T>
-        static inline void pack( Stream& s, const T& v, uint32_t _max_depth )
-        {
-           FC_ASSERT( false, "Please implement pack(...)" );
-        }
-        template<typename Stream, typename T>
-        static inline void unpack( Stream& s, T& v, uint32_t _max_depth )
-        {
-           FC_ASSERT( false, "Please implement unpack(...)" );
-        }
-      };
+      struct if_class;
 
       template<>
       struct if_class<fc::false_type> {

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -354,9 +354,15 @@ namespace fc {
       template<typename IsClass=fc::true_type>
       struct if_class{
         template<typename Stream, typename T>
-        static inline void pack( Stream& s, const T& v, uint32_t _max_depth ) { s << v; }
+        static inline void pack( Stream& s, const T& v, uint32_t _max_depth )
+        {
+           FC_ASSERT( false, "Please implement pack(...)" );
+        }
         template<typename Stream, typename T>
-        static inline void unpack( Stream& s, T& v, uint32_t _max_depth ) { s >> v; }
+        static inline void unpack( Stream& s, T& v, uint32_t _max_depth )
+        {
+           FC_ASSERT( false, "Please implement unpack(...)" );
+        }
       };
 
       template<>

--- a/include/fc/io/raw_fwd.hpp
+++ b/include/fc/io/raw_fwd.hpp
@@ -22,6 +22,11 @@ namespace fc {
    class path;
    template<typename... Types> class static_variant;
 
+   class sha224;
+   class sha256;
+   class sha512;
+   class ripemd160;
+
    template<typename IntType, typename EnumType> class enum_type;
    namespace ip { class endpoint; }
 
@@ -95,6 +100,15 @@ namespace fc {
     template<typename Stream> void pack( Stream& s, const fc::ecc::public_key&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
     template<typename Stream> void unpack( Stream& s, fc::ecc::private_key&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
     template<typename Stream> void pack( Stream& s, const fc::ecc::private_key&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+
+    template<typename Stream> inline void unpack( Stream& s, fc::sha224&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+    template<typename Stream> inline void pack( Stream& s, const fc::sha224&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+    template<typename Stream> inline void unpack( Stream& s, fc::sha256&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+    template<typename Stream> inline void pack( Stream& s, const fc::sha256&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+    template<typename Stream> inline void unpack( Stream& s, fc::sha512&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+    template<typename Stream> inline void pack( Stream& s, const fc::sha512&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+    template<typename Stream> inline void unpack( Stream& s, fc::ripemd160&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+    template<typename Stream> inline void pack( Stream& s, const fc::ripemd160&, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
 
     template<typename Stream, typename T> inline void pack( Stream& s, const T& v, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
     template<typename Stream, typename T> inline void unpack( Stream& s, T& v, uint32_t _max_depth=FC_PACK_MAX_DEPTH );

--- a/tests/serialization_test.cpp
+++ b/tests/serialization_test.cpp
@@ -35,59 +35,8 @@ namespace fc { namespace test {
    inline bool operator < ( const item& a, const item& b )
    { return ( std::tie( a.level, a.w ) < std::tie( b.level, b.w ) ); }
 
-   class class_item;
-
-   class class_item_wrapper
-   {
-      public:
-         class_item_wrapper() {}
-         class_item_wrapper(class_item&& it) { v.reserve(1); v.emplace_back( it ); }
-         std::vector<class class_item> v;
-   };
-   inline bool operator == ( const class_item_wrapper& a, const class_item_wrapper& b )
-   { return ( std::tie( a.v ) == std::tie( b.v ) ); }
-
-   class class_item
-   {
-      public:
-         class_item(int32_t lvl = 0) : level(lvl) {}
-         class_item(class_item_wrapper&& wp, int32_t lvl = 0) : level(lvl), w(wp) {}
-         int32_t            level;
-         class_item_wrapper w;
-   };
-   inline bool operator == ( const class_item& a, const class_item& b )
-   { return ( std::tie( a.level, a.w ) == std::tie( b.level, b.w ) ); }
-
-   template<typename Stream>
-   void operator >> ( Stream& s, class_item_wrapper& w )
-   {
-      fc::raw::unpack( s, w.v );
-   }
-   template<typename Stream>
-   void operator << ( Stream& s, const class_item_wrapper& w )
-   {
-      fc::raw::pack( s, w.v );
-   }
-
-   template<typename Stream>
-   void operator >> ( Stream& s, class_item& it )
-   {
-      fc::raw::unpack( s, it.level );
-      fc::raw::unpack( s, it.w );
-   }
-   template<typename Stream>
-   void operator << ( Stream& s, const class_item& it )
-   {
-      fc::raw::pack( s, it.level );
-      fc::raw::pack( s, it.w );
-   }
 
 } } // namespace fc::test
-
-namespace fc {
-   template<> struct get_typename<fc::test::class_item>  { static const char* name()  { return "class_item";  } };
-   template<> struct get_typename<fc::test::class_item_wrapper>  { static const char* name()  { return "class_item_wrapper";  } };
-}
 
 FC_REFLECT( fc::test::item_wrapper, (v) );
 FC_REFLECT( fc::test::item, (level)(w) );
@@ -107,20 +56,6 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
             ilog( "Creating level ${lv}", ("lv",i) );
          fc::test::item_wrapper wp( std::move(nested) );
          nested = fc::test::item( std::move(wp), i );
-      }
-      return nested;
-   };
-
-   auto create_nested_class_object = []( uint32_t level )
-   {
-      ilog( "Creating nested class object with ${lv} level(s)", ("lv",level) );
-      fc::test::class_item nested;
-      for( uint32_t i = 1; i <= level; i++ )
-      {
-         if( i % 100 == 0 )
-            ilog( "Creating level ${lv}", ("lv",i) );
-         fc::test::class_item_wrapper wp( std::move(nested) );
-         nested = fc::test::class_item( std::move(wp), i );
       }
       return nested;
    };
@@ -162,30 +97,6 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
 
       BOOST_TEST_MESSAGE( "About to unpack." );
       fc::test::item unpacked;
-      BOOST_CHECK_THROW( fc::raw::unpack( ss, unpacked ), fc::assert_exception );
-   }
-
-   // 150 levels, by default packing will fail
-   {
-      auto nested = create_nested_class_object( 150 );
-
-      std::stringstream ss;
-
-      BOOST_TEST_MESSAGE( "About to pack." );
-      BOOST_CHECK_THROW( fc::raw::pack( ss, nested ), fc::assert_exception );
-   }
-
-   // 150 levels and allow packing, unpacking will fail
-   {
-      auto nested = create_nested_object( 150 );
-
-      std::stringstream ss;
-
-      BOOST_TEST_MESSAGE( "About to pack." );
-      fc::raw::pack( ss, nested, 1500 );
-
-      BOOST_TEST_MESSAGE( "About to unpack as class object." );
-      fc::test::class_item unpacked;
       BOOST_CHECK_THROW( fc::raw::unpack( ss, unpacked ), fc::assert_exception );
    }
 

--- a/tests/serialization_test.cpp
+++ b/tests/serialization_test.cpp
@@ -7,8 +7,8 @@
 namespace fc { namespace test {
 
    struct item;
-   inline bool operator < ( const item& a, const item& b );
    inline bool operator == ( const item& a, const item& b );
+   inline bool operator < ( const item& a, const item& b );
 
    struct item_wrapper
    {
@@ -16,8 +16,11 @@ namespace fc { namespace test {
       item_wrapper(item&& it) { v.reserve(1); v.insert( it ); }
       boost::container::flat_set<struct item> v;
    };
-   inline bool operator < ( const item_wrapper& a, const item_wrapper& b );
-   inline bool operator == ( const item_wrapper& a, const item_wrapper& b );
+
+   inline bool operator == ( const item_wrapper& a, const item_wrapper& b )
+   { return ( std::tie( a.v ) == std::tie( b.v ) ); }
+   inline bool operator < ( const item_wrapper& a, const item_wrapper& b )
+   { return ( std::tie( a.v ) < std::tie( b.v ) ); }
 
    struct item
    {
@@ -29,17 +32,62 @@ namespace fc { namespace test {
 
    inline bool operator == ( const item& a, const item& b )
    { return ( std::tie( a.level, a.w ) == std::tie( b.level, b.w ) ); }
-
    inline bool operator < ( const item& a, const item& b )
    { return ( std::tie( a.level, a.w ) < std::tie( b.level, b.w ) ); }
 
-   inline bool operator == ( const item_wrapper& a, const item_wrapper& b )
+   class class_item;
+
+   class class_item_wrapper
+   {
+      public:
+         class_item_wrapper() {}
+         class_item_wrapper(class_item&& it) { v.reserve(1); v.emplace_back( it ); }
+         std::vector<class class_item> v;
+   };
+   inline bool operator == ( const class_item_wrapper& a, const class_item_wrapper& b )
    { return ( std::tie( a.v ) == std::tie( b.v ) ); }
 
-   inline bool operator < ( const item_wrapper& a, const item_wrapper& b )
-   { return ( std::tie( a.v ) < std::tie( b.v ) ); }
+   class class_item
+   {
+      public:
+         class_item(int32_t lvl = 0) : level(lvl) {}
+         class_item(class_item_wrapper&& wp, int32_t lvl = 0) : level(lvl), w(wp) {}
+         int32_t            level;
+         class_item_wrapper w;
+   };
+   inline bool operator == ( const class_item& a, const class_item& b )
+   { return ( std::tie( a.level, a.w ) == std::tie( b.level, b.w ) ); }
 
-} }
+   template<typename Stream>
+   void operator >> ( Stream& s, class_item_wrapper& w )
+   {
+      fc::raw::unpack( s, w.v );
+   }
+   template<typename Stream>
+   void operator << ( Stream& s, const class_item_wrapper& w )
+   {
+      fc::raw::pack( s, w.v );
+   }
+
+   template<typename Stream>
+   void operator >> ( Stream& s, class_item& it )
+   {
+      fc::raw::unpack( s, it.level );
+      fc::raw::unpack( s, it.w );
+   }
+   template<typename Stream>
+   void operator << ( Stream& s, const class_item& it )
+   {
+      fc::raw::pack( s, it.level );
+      fc::raw::pack( s, it.w );
+   }
+
+} } // namespace fc::test
+
+namespace fc {
+   template<> struct get_typename<fc::test::class_item>  { static const char* name()  { return "class_item";  } };
+   template<> struct get_typename<fc::test::class_item_wrapper>  { static const char* name()  { return "class_item_wrapper";  } };
+}
 
 FC_REFLECT( fc::test::item_wrapper, (v) );
 FC_REFLECT( fc::test::item, (level)(w) );
@@ -59,6 +107,20 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
             ilog( "Creating level ${lv}", ("lv",i) );
          fc::test::item_wrapper wp( std::move(nested) );
          nested = fc::test::item( std::move(wp), i );
+      }
+      return nested;
+   };
+
+   auto create_nested_class_object = []( uint32_t level )
+   {
+      ilog( "Creating nested class object with ${lv} level(s)", ("lv",level) );
+      fc::test::class_item nested;
+      for( uint32_t i = 1; i <= level; i++ )
+      {
+         if( i % 100 == 0 )
+            ilog( "Creating level ${lv}", ("lv",i) );
+         fc::test::class_item_wrapper wp( std::move(nested) );
+         nested = fc::test::class_item( std::move(wp), i );
       }
       return nested;
    };
@@ -100,6 +162,30 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
 
       BOOST_TEST_MESSAGE( "About to unpack." );
       fc::test::item unpacked;
+      BOOST_CHECK_THROW( fc::raw::unpack( ss, unpacked ), fc::assert_exception );
+   }
+
+   // 150 levels, by default packing will fail
+   {
+      auto nested = create_nested_class_object( 150 );
+
+      std::stringstream ss;
+
+      BOOST_TEST_MESSAGE( "About to pack." );
+      BOOST_CHECK_THROW( fc::raw::pack( ss, nested ), fc::assert_exception );
+   }
+
+   // 150 levels and allow packing, unpacking will fail
+   {
+      auto nested = create_nested_object( 150 );
+
+      std::stringstream ss;
+
+      BOOST_TEST_MESSAGE( "About to pack." );
+      fc::raw::pack( ss, nested, 1500 );
+
+      BOOST_TEST_MESSAGE( "About to unpack as class object." );
+      fc::test::class_item unpacked;
       BOOST_CHECK_THROW( fc::raw::unpack( ss, unpacked ), fc::assert_exception );
    }
 


### PR DESCRIPTION
Deprecate default `pack` and `unpack` functions which was formerly implemented with I/O operators (`<<` and `>>`).

This will break serialization of `graphene::chain::extension<>` in bitshares-core.

Perhaps better to remove the functions directly, so errors will raise at compile time?