### PR TITLE
Fix redefinition of default arg under macOS

### DIFF
--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -561,7 +561,7 @@ namespace fc
       to_variant( val, *this, max_depth );
    }
    #ifdef __APPLE__
-   inline void to_variant( size_t s, variant& v, uint32_t max_depth = 1 ) { v = variant(uint64_t(s)); }
+   inline void to_variant( size_t s, variant& v, uint32_t max_depth ) { v = variant(uint64_t(s)); }
    #endif
    template<typename T>
    void to_variant( const std::shared_ptr<T>& var, variant& vo, uint32_t max_depth )


### PR DESCRIPTION
There is a definition with default argument in the same file, line 152 as of writing.