### PR TITLE
Pipe output to get around logging ANSI color issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ install:
 script:
  - cmake -DCMAKE_BUILD_TYPE=Debug -DBoost_USE_STATIC_LIBS=OFF .
  - make -j 2
- - tests/all_tests
+ - set -o pipefail
+ - tests/all_tests 2>&1 | cat


### PR DESCRIPTION
`set -o pipefail` is for tracking exit status of `all_tests`.