### PR TITLE
Remove -std=c++14 flag from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@
 PROJECT( fc )
 CMAKE_MINIMUM_REQUIRED( VERSION 2.8.12 )
 
-add_compile_options(-std=c++14)
-
 MESSAGE(STATUS "Configuring project fc located in: ${CMAKE_CURRENT_SOURCE_DIR}")
 SET( CMAKE_AUTOMOC OFF )
 


### PR DESCRIPTION
We aren't really using c++14. Remove the requirement so we can build in Ubuntu 14.04 with default shipped gcc 4.8.