### PR TITLE
Add special handling for mac size_t and variant

### DIFF
--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -211,6 +211,9 @@ namespace fc
         variant( uint32_t val, uint32_t max_depth = 1 );
         variant( int32_t val, uint32_t max_depth = 1 );
         variant( uint64_t val, uint32_t max_depth = 1 );
+#ifdef __APPLE__
+        variant( size_t val, uint32_t max_depth = 1 );
+#endif
         variant( int64_t val, uint32_t max_depth = 1 );
         variant( double val, uint32_t max_depth = 1 );
         variant( bool val, uint32_t max_depth = 1 );

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -74,6 +74,14 @@ variant::variant( uint64_t val, uint32_t max_depth )
    set_variant_type( this, uint64_type );
 }
 
+#ifdef __APPLE__
+variant::variant( size_t val, uint32_t max_depth )
+{
+   *reinterpret_cast<uint64_t*>(this)  = val;
+   set_variant_type( this, uint64_type );
+}
+#endif
+
 variant::variant( int64_t val, uint32_t max_depth )
 {
    *reinterpret_cast<int64_t*>(this)  = val;


### PR DESCRIPTION
mac has a different definition for size_t, which cause fc::variant to not compile. These changes handle size_t for __APPLE__