### PR TITLE
Fixed DH memory handling with openssl-1.1

### DIFF
--- a/src/crypto/dh.cpp
+++ b/src/crypto/dh.cpp
@@ -18,8 +18,8 @@ namespace fc {
         ssl_dh dh(DH_new());
         DH_generate_parameters_ex(dh.obj, s, g, NULL);
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-        ssl_bignum bn_p;
-        DH_get0_pqg(dh.obj, (const BIGNUM**)&bn_p.obj, NULL, NULL);
+        const BIGNUM* bn_p; // must not be free'd!
+        DH_get0_pqg(dh.obj, &bn_p, NULL, NULL);
         p.resize( BN_num_bytes( bn_p ) );
         if( p.size() )
             BN_bn2bin( bn_p, (unsigned char*)&p.front()  );
@@ -69,15 +69,15 @@ namespace fc {
         DH_generate_key(dh);
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-        ssl_bignum bn_pub_key;
-        ssl_bignum bn_priv_key;
-        DH_get0_key(dh.obj, (const BIGNUM**)&bn_pub_key.obj, (const BIGNUM**)&bn_priv_key.obj);
+        const BIGNUM* bn_pub_key; // must not be free'd!
+        const BIGNUM* bn_priv_key; // must not be free'd!
+        DH_get0_key(dh.obj, &bn_pub_key, &bn_priv_key);
         pub_key.resize( BN_num_bytes( bn_pub_key ) );
         priv_key.resize( BN_num_bytes( bn_priv_key ) );
         if( pub_key.size() )
-            BN_bn2bin( bn_pub_key.obj, (unsigned char*)&pub_key.front()  );
+            BN_bn2bin( bn_pub_key, (unsigned char*)&pub_key.front()  );
         if( priv_key.size() )
-            BN_bn2bin( bn_priv_key.obj, (unsigned char*)&priv_key.front()  );
+            BN_bn2bin( bn_priv_key, (unsigned char*)&priv_key.front()  );
 #else
         pub_key.resize( BN_num_bytes( dh->pub_key ) );
         priv_key.resize( BN_num_bytes( dh->priv_key ) );

--- a/src/crypto/elliptic_common.cpp
+++ b/src/crypto/elliptic_common.cpp
@@ -231,11 +231,12 @@ namespace fc { namespace ecc {
 
     static fc::string _to_base58( const extended_key_data& key )
     {
-        char *buffer = (char*)alloca(key.size() + 4);
+        size_t buf_len = key.size() + 4;
+        char *buffer = (char*)alloca(buf_len);
         memcpy( buffer, key.begin(), key.size() );
         fc::sha256 double_hash = fc::sha256::hash( fc::sha256::hash( key.begin(), key.size() ));
         memcpy( buffer + key.size(), double_hash.data(), 4 );
-        return fc::to_base58( buffer, sizeof(buffer) );
+        return fc::to_base58( buffer, buf_len );
     }
 
     static void _parse_extended_data( unsigned char* buffer, fc::string base58 )

--- a/src/crypto/elliptic_secp256k1.cpp
+++ b/src/crypto/elliptic_secp256k1.cpp
@@ -193,7 +193,7 @@ namespace fc { namespace ecc {
             unsigned char *buffer = (unsigned char*)alloca(len + 1);
             *buffer = 0;
             memcpy( buffer + 1, in, len );
-            BN_bin2bn( buffer, sizeof(buffer), out );
+            BN_bin2bn( buffer, len + 1, out );
         }
         else
         {


### PR DESCRIPTION
According to the documentation, DH_get0 returns pointers to existing data structures controlled by the DH object. These pointers must not be free'd.
https://www.openssl.org/docs/man1.1.0/crypto/DH_get0_pqg.html