### PR TITLE
Wallet CLI "core dump" when importing key

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -241,7 +241,7 @@ namespace fc {
   void remove_all( const path& p ) { boost::filesystem::remove_all(p); }
   void copy( const path& f, const path& t ) { 
      try {
-  	    boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t) ); 
+  	    boost::filesystem::copy_file( boost::filesystem::path(f), boost::filesystem::path(t) ); 
      } catch ( boost::system::system_error& e ) {
      	FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}",
 	         ("srcfile",f)("dstfile",t)("reason",e.what() ) );


### PR DESCRIPTION
bitshares-core/libraries/fc/src/filesystem.cpp
```c++
void copy( const path& f, const path& t ) { 
     try {
       boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t) );
     } catch ( boost::system::system_error& e ) {
      FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}",
          ("srcfile",f)("dstfile",t)("reason",e.what() ) );
     } catch ( ... ) {
      FC_THROW( "Copy from ${srcfile} to ${dstfile} failed",
          ("srcfile",f)("dstfile",t)("inner", fc::except_str() ) );
     }
  }
```
"boost::filesystem::copy" will cause a core dump on macOS High Sierra 10.13.4 compiled by "clang-902.9.39.1"