### PR TITLE
Fixed diffie-hellman shared key computation

### DIFF
--- a/src/crypto/dh.cpp
+++ b/src/crypto/dh.cpp
@@ -69,8 +69,12 @@ namespace fc {
 
         ssl_bignum pk;
         BN_bin2bn( (unsigned char*)buf, s, pk );
-        shared_key.resize( DH_size(dh) ); 
-        DH_compute_key( (unsigned char*)&shared_key.front(), pk, dh );
+        int est_size = DH_size(dh);
+        shared_key.resize( est_size );
+        int actual_size = DH_compute_key( (unsigned char*)&shared_key.front(), pk, dh );
+        if ( actual_size < 0 ) return false;
+        if ( actual_size != est_size )
+           shared_key.resize( actual_size );
 
         return true;
    }

--- a/tests/crypto/dh_test.cpp
+++ b/tests/crypto/dh_test.cpp
@@ -52,15 +52,37 @@ BOOST_AUTO_TEST_CASE(dh_test)
     alice.p = bob.p;
     alice.g = 9;
     BOOST_CHECK( !alice.validate() );
+}
 
-// It ain't easy...
-//    alice.g = 2;
-//    BOOST_CHECK( alice.validate() );
-//    BOOST_CHECK( alice.generate_pub_key() );
-//    BOOST_CHECK( alice.compute_shared_key( bob.pub_key ) );
-//    BOOST_CHECK( bob.compute_shared_key( alice.pub_key ) );
-//    BOOST_CHECK_EQUAL( alice.shared_key.size(), bob.shared_key.size() );
-//    BOOST_CHECK( memcmp( alice.shared_key.data(), bob.shared_key.data(), alice.shared_key.size() ) );
+static const std::string P(          "\344\005\357H\277<\305\356\006*\312\326\265\347;\363" );
+static const std::string ALICE_PUB(  "\015\343p\243\344d\3600\015/UL\340\277\243\203" );
+static const std::string ALICE_PRIV( "oJ'\363\227\243\346\215/V\253\036i\250\370\233" );
+static const std::string BOB_PUB(    "26x`3\017A\365\334\022\031\231\032Y\242\242" );
+static const std::string BOB_PRIV(   "d\300\327v?jG4\340\037k\221\230z\372\203" );
+static const std::string SHARED_KEY( "\303.\236g\25767!\006\365u\341;o\241" );
+BOOST_AUTO_TEST_CASE(dh_size_mismatch_test)
+{
+   fc::diffie_hellman alice;
+   alice.p.insert( alice.p.begin(), P.begin(), P.end() );
+   alice.pub_key.insert( alice.pub_key.begin(), ALICE_PUB.begin(), ALICE_PUB.end() );
+   alice.priv_key.insert( alice.priv_key.begin(), ALICE_PRIV.begin(), ALICE_PRIV.end() );
+   alice.g = 5;
+   BOOST_CHECK( alice.validate() );
+
+   fc::diffie_hellman bob;
+   bob.p = alice.p;
+   bob.pub_key.insert( bob.pub_key.begin(), BOB_PUB.begin(), BOB_PUB.end() );
+   bob.priv_key.insert( bob.priv_key.begin(), BOB_PRIV.begin(), BOB_PRIV.end() );
+   bob.g = alice.g;
+   BOOST_CHECK( bob.validate() );
+
+   BOOST_CHECK( alice.compute_shared_key( bob.pub_key ) );
+   BOOST_CHECK( bob.compute_shared_key( alice.pub_key ) );
+   BOOST_CHECK_EQUAL( 15, alice.shared_key.size() );
+   BOOST_CHECK_EQUAL( 15, bob.shared_key.size() );
+   BOOST_CHECK( !memcmp( alice.shared_key.data(), bob.shared_key.data(), alice.shared_key.size() ) );
+
+   BOOST_CHECK_EQUAL( SHARED_KEY, std::string( alice.shared_key.begin(), alice.shared_key.end() ) );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/crypto/dh_test.cpp
+++ b/tests/crypto/dh_test.cpp
@@ -41,14 +41,11 @@ BOOST_AUTO_TEST_CASE(dh_test)
     BOOST_CHECK( !memcmp( charlie.shared_key.data(), bob.shared_key.data(), bob.shared_key.size() ) );
     std::vector<char> bob_charlie = charlie.shared_key;
 
-    BOOST_CHECK_EQUAL( alice_bob.size(), alice_charlie.size() );
-    BOOST_CHECK( memcmp( alice_bob.data(), alice_charlie.data(), alice_bob.size() ) );
+    BOOST_CHECK( alice_bob.size() != alice_charlie.size() ||  memcmp( alice_bob.data(), alice_charlie.data(), alice_bob.size() ) );
 
-    BOOST_CHECK_EQUAL( alice_bob.size(), bob_charlie.size() );
-    BOOST_CHECK( memcmp( alice_bob.data(), bob_charlie.data(), alice_bob.size() ) );
+    BOOST_CHECK( alice_bob.size() != bob_charlie.size() || memcmp( alice_bob.data(), bob_charlie.data(), alice_bob.size() ) );
 
-    BOOST_CHECK_EQUAL( alice_charlie.size(), bob_charlie.size() );
-    BOOST_CHECK( memcmp( alice_charlie.data(), bob_charlie.data(), alice_charlie.size() ) );
+    BOOST_CHECK( alice_charlie.size() != bob_charlie.size() || memcmp( alice_charlie.data(), bob_charlie.data(), alice_charlie.size() ) );
 
     alice.p.clear(); alice.p.push_back(100); alice.p.push_back(2);
     BOOST_CHECK( !alice.validate() );


### PR DESCRIPTION
The shared secret computed by DH_compute_key can be smaller than the estimate provided with DH_size. This must be accounted for, otherwise there will be uninitialized trailing bytes in the resulting shared_key vector.
https://www.openssl.org/docs/man1.0.2/crypto/DH_compute_key.html