### PR TITLE
Modifications to run sonar-scanner during travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ sudo: true
 install:
  - echo "deb http://de.archive.ubuntu.com/ubuntu xenial main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
  - sudo apt-get update
- - sudo apt-get install --allow-unauthenticated g++ libboost-all-dev cmake libreadline-dev libssl-dev autoconf
+ - sudo apt-get install --allow-unauthenticated g++ libboost-all-dev cmake libreadline-dev libssl-dev autoconf parallel
 
 addons:
   sonarcloud:
@@ -22,7 +22,7 @@ script:
  - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF  -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON .
  - 'which build-wrapper-linux-x86-64 && build-wrapper-linux-x86-64 --out-dir bw-output make -j 2 || make -j 2'
  - set -o pipefail
- - tests/all_tests 2>&1 | cat
+ - tests/run-parallel-tests.sh tests/all_tests
  - "tests/api 2>&1 | grep -vE 'callback result 9|remote_calc->add. 4, 5 .: 9|set callback|] \\.$'"
  - tests/bip_lock 2>&1 | cat
  - tests/hmac_test 2>&1 | cat

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 
 script:
  - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF  -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON .
- - build-wrapper-linux-x86-64 --out-dir bw-output make -j 2
+ - 'which build-wrapper-linux-x86-64 && build-wrapper-linux-x86-64 --out-dir bw-output make -j 2 || make -j 2'
  - set -o pipefail
  - tests/all_tests 2>&1 | cat
  - "tests/api 2>&1 | grep -vE 'callback result 9|remote_calc->add. 4, 5 .: 9|set callback|] \\.$'"
@@ -29,4 +29,4 @@ script:
  - tests/ecc_test README.md 2>&1 | cat
  - tests/log_test 2>&1 | cat
  - 'find CMakeFiles/fc.dir -type d | while read d; do gcov -o "$d" "${d/CMakeFiles*.dir/./}"/*.cpp; done >/dev/null'
- - sonar-scanner
+ - 'which sonar-scanner && sonar-scanner || true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,21 @@ install:
  - sudo apt-get update
  - sudo apt-get install --allow-unauthenticated g++ libboost-all-dev cmake libreadline-dev libssl-dev autoconf
 
+addons:
+  sonarcloud:
+    organization: "flwyiq7go36p6lipr64tbesy5jayad3q"
+    token:
+      secure: "Y0DhI1Fn7QXqdYF5kCUFV0l0XUOp5iYp+kHYVAWpt1HSYN5889GTO3SgsZoT7+Cmo1HLAe2P8tSCzz3lECDI0rWMuk7wxFRMVmnxBpbR5P61+Mhe4t/LhSGzuT3PAscttFNPexpDmePKO0EgTY7PemMtXR8LZ2O/RngAMWWfH0Wmyngy68Bm9CvpWfW9aQ8ZUMsjpbDmbaE9dN6FLABE1YZzVL+9SA07gOSQzry/SLbRY19+g9OicaAoCdQCdvIem6af1qIy0x5uDFfz4x1Sows9awBOsAOf6V5WmFlV21YwR1RhT+4WffB+VrMYOF8YpzoUrS+CPmPWlkDDN3fuKsqRGYpbBIxyqBQ+rahDtXfoD5ZbGY1UYTbrHGD8VTNVbvdqAsVEfgZ8ci7NxBnIL3VDduxP1qb46chTJb9KeeIETtN8qTdfsZyudveZLKmULKah8uaOkMX2bJT6oikluVXJnI0OybHQrrMwHula/qmEj3FnC3KKPmL84F/6DSPiiojx+qsMa0STQE9ZwzeJPc8KjllsTYKL492IDQJDXkWGS+PwlOXResr2Dhu/rfYKy6qpHQJzreoPcIRmeM7rFamJZHkqdaldJGm+iQacX2byKJ/tT93IM6hW0BEi4Haucwn1f0Ig5tzE8mzro1/Rj35a9ti2jmO0NWjyeBwnCVo="
+
 script:
- - cmake -DCMAKE_BUILD_TYPE=Debug -DBoost_USE_STATIC_LIBS=OFF .
- - make -j 2
+ - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage -DBoost_USE_STATIC_LIBS=OFF  -DCMAKE_CXX_OUTPUT_EXTENSION_REPLACE=ON .
+ - build-wrapper-linux-x86-64 --out-dir bw-output make -j 2
  - set -o pipefail
  - tests/all_tests 2>&1 | cat
+ - "tests/api 2>&1 | grep -vE 'callback result 9|remote_calc->add. 4, 5 .: 9|set callback|] \\.$'"
+ - tests/bip_lock 2>&1 | cat
+ - tests/hmac_test 2>&1 | cat
+ - tests/ecc_test README.md 2>&1 | cat
+ - tests/log_test 2>&1 | cat
+ - 'find CMakeFiles/fc.dir -type d | while read d; do gcov -o "$d" "${d/CMakeFiles*.dir/./}"/*.cpp; done >/dev/null'
+ - sonar-scanner

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=BitShares-FC
+sonar.projectName=BitShares-FC
+
+sonar.links.homepage=https://bitshares.org
+sonar.links.ci=https://travis-ci.org/bitshares/bitshares-fc/
+sonar.links.issue=https://github.com/bitshares/bitshares-core/issues
+sonar.links.scm=https://github.com/bitshares/bitshares-fc/tree/master
+
+sonar.tests=tests
+sonar.exclusions=vendor/**/*,tests/**/*
+sonar.sources=src,include
+sonar.cfamily.build-wrapper-output=bw-output
+sonar.cfamily.gcov.reportsPath=.
+sonar.cfamily.threads=2

--- a/tests/run-parallel-tests.sh
+++ b/tests/run-parallel-tests.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ "$#" != 1 ]; then
+    echo "Usage: $0 <boost-unit-test-executable>" 1>&2
+    exit 1
+fi
+
+"$1" --list_content 2>&1 \
+  | grep '\*$' \
+  | sed 's=\*$==;s=^    =/=' \
+  | while read t; do
+	case "$t" in
+	/*) echo "$pre$t"; ;;
+	*) pre="$t"; ;;
+	esac
+    done \
+  | parallel echo Running {}\; "$1" -t {}
+


### PR DESCRIPTION
Experimental - one known problem is that encrypted parameters in .travis.yml may not be available when building PRs from foreign repos. Like this one.