### PR TITLE
Remove hard coded number of IO threads

### DIFF
--- a/include/fc/asio.hpp
+++ b/include/fc/asio.hpp
@@ -78,7 +78,7 @@ namespace asio {
        public:
           default_io_service_scope();
           ~default_io_service_scope();
-          static void set_default_num_threads(int16_t num_threads);
+          static int16_t set_default_num_threads(int16_t num_threads);
           boost::asio::io_service*          io;
        private:
           std::vector<boost::thread*>       asio_threads;

--- a/include/fc/asio.hpp
+++ b/include/fc/asio.hpp
@@ -78,13 +78,13 @@ namespace asio {
        public:
           default_io_service_scope();
           ~default_io_service_scope();
-          static int16_t set_default_num_threads(int16_t num_threads);
+          static void set_num_threads(uint16_t num_threads);
           boost::asio::io_service*          io;
        private:
           std::vector<boost::thread*>       asio_threads;
           boost::asio::io_service::work*    the_work;
        protected:
-          int16_t get_default_num_threads(); // helps with testing
+          static uint16_t num_io_threads; // marked private to help with testing
     };
 
     /**

--- a/include/fc/asio.hpp
+++ b/include/fc/asio.hpp
@@ -84,7 +84,7 @@ namespace asio {
           std::vector<boost::thread*>       asio_threads;
           boost::asio::io_service::work*    the_work;
        protected:
-          static uint16_t num_io_threads; // marked private to help with testing
+          static uint16_t num_io_threads; // marked protected to help with testing
     };
 
     /**

--- a/include/fc/asio.hpp
+++ b/include/fc/asio.hpp
@@ -65,7 +65,8 @@ namespace asio {
             bool operator()( C&, bool ) { return false; } 
         };
         #endif 
-    }
+    } // end of namespace detail
+
     /**
      * @return the default boost::asio::io_service for use with fc::asio
      * 

--- a/include/fc/asio.hpp
+++ b/include/fc/asio.hpp
@@ -5,6 +5,8 @@
 #pragma once
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
+#include <boost/thread.hpp>
+#include <vector>
 #include <fc/thread/future.hpp>
 #include <fc/io/iostream.hpp>
 
@@ -66,6 +68,24 @@ namespace asio {
         };
         #endif 
     } // end of namespace detail
+
+    /***
+     * A structure for holding the boost io service and associated
+     * threads
+     */
+    class default_io_service_scope
+    {
+       public:
+          default_io_service_scope();
+          ~default_io_service_scope();
+          static void set_default_num_threads(int16_t num_threads);
+          boost::asio::io_service*          io;
+       private:
+          std::vector<boost::thread*>       asio_threads;
+          boost::asio::io_service::work*    the_work;
+       protected:
+          int16_t get_default_num_threads(); // helps with testing
+    };
 
     /**
      * @return the default boost::asio::io_service for use with fc::asio

--- a/src/asio.cpp
+++ b/src/asio.cpp
@@ -123,7 +123,7 @@ namespace fc {
           this->num_io_threads = std::max( boost::thread::hardware_concurrency(), 8u );
        }
 
-       for( int16_t i = 0; i < this->num_io_threads; ++i )
+       for( uint16_t i = 0; i < this->num_io_threads; ++i )
        {
           asio_threads.push_back( new boost::thread( [=]()
                 {

--- a/src/asio.cpp
+++ b/src/asio.cpp
@@ -122,10 +122,8 @@ namespace fc {
        if (default_num_io_threads == 0)
        {
           // the default was not set by the configuration. Determine a good
-          // number of threads. Minimum of 2, maximum of hardware_concurrency - 1
-          default_num_io_threads = std::max( boost::thread::hardware_concurrency(), 2u );
-          if( default_num_io_threads > 2 )
-             --default_num_io_threads;
+          // number of threads. Minimum of 8, maximum of hardware_concurrency
+          default_num_io_threads = std::max( boost::thread::hardware_concurrency(), 8u );
        }
 
        for( int16_t i = 0; i < default_num_io_threads; ++i )

--- a/src/asio.cpp
+++ b/src/asio.cpp
@@ -93,22 +93,19 @@ namespace fc {
         }
     }
 
-    static int16_t default_num_io_threads = 0;
+    uint16_t fc::asio::default_io_service_scope::num_io_threads = 0;
 
     /***
      * @brief set the default number of threads for the io service
      *
+     * Sets the number of threads for the io service. This will throw
+     * an exception if called more than once.
+     *
      * @param num_threads the number of threads
-     * @returns the old value. If the old value is not 0, you've probably called this method too late.
      */
-    int16_t default_io_service_scope::set_default_num_threads(int16_t num_threads) {
-       int16_t old_value = default_num_io_threads;
-       default_num_io_threads = num_threads;
-       return old_value;
-    }
-
-    int16_t default_io_service_scope::get_default_num_threads() {
-       return default_num_io_threads;
+    void default_io_service_scope::set_num_threads(uint16_t num_threads) {
+       FC_ASSERT(fc::asio::default_io_service_scope::num_io_threads == 0);
+       fc::asio::default_io_service_scope::num_io_threads = num_threads;
     }
 
     /***
@@ -119,14 +116,14 @@ namespace fc {
        io           = new boost::asio::io_service();
        the_work     = new boost::asio::io_service::work(*io);
 
-       if (default_num_io_threads == 0)
+       if (this->num_io_threads == 0)
        {
           // the default was not set by the configuration. Determine a good
           // number of threads. Minimum of 8, maximum of hardware_concurrency
-          default_num_io_threads = std::max( boost::thread::hardware_concurrency(), 8u );
+          this->num_io_threads = std::max( boost::thread::hardware_concurrency(), 8u );
        }
 
-       for( int16_t i = 0; i < default_num_io_threads; ++i )
+       for( int16_t i = 0; i < this->num_io_threads; ++i )
        {
           asio_threads.push_back( new boost::thread( [=]()
                 {

--- a/src/asio.cpp
+++ b/src/asio.cpp
@@ -123,7 +123,7 @@ namespace fc {
        {
           // the default was not set by the configuration. Determine a good
           // number of threads. Minimum of 2, maximum of hardware_concurrency - 1
-          default_num_io_threads = std::max( std::thread::hardware_concurrency(), 2u );
+          default_num_io_threads = std::max( boost::thread::hardware_concurrency(), 2u );
           if( default_num_io_threads > 2 )
              --default_num_io_threads;
        }

--- a/src/asio.cpp
+++ b/src/asio.cpp
@@ -99,9 +99,12 @@ namespace fc {
      * @brief set the default number of threads for the io service
      *
      * @param num_threads the number of threads
+     * @returns the old value. If the old value is not 0, you've probably called this method too late.
      */
-    void default_io_service_scope::set_default_num_threads(int16_t num_threads) {
+    int16_t default_io_service_scope::set_default_num_threads(int16_t num_threads) {
+       int16_t old_value = default_num_io_threads;
        default_num_io_threads = num_threads;
+       return old_value;
     }
 
     int16_t default_io_service_scope::get_default_num_threads() {

--- a/tests/io/tcp_test.cpp
+++ b/tests/io/tcp_test.cpp
@@ -18,10 +18,11 @@ BOOST_AUTO_TEST_CASE(tcpconstructor_test)
 class my_io_class : public fc::asio::default_io_service_scope
 {
 public:
-   int16_t get_num_threads()
+   uint16_t get_num_threads()
    {
-      return get_default_num_threads();
+      return fc::asio::default_io_service_scope::num_io_threads;
    }
+   static void reset_num_threads() { fc::asio::default_io_service_scope::num_io_threads = 0; }
 };
 
 /***
@@ -29,7 +30,10 @@ public:
  */
 BOOST_AUTO_TEST_CASE( number_threads_test )
 {
-   fc::asio::default_io_service_scope::set_default_num_threads(12);
+   // to erase leftovers from previous tests
+   my_io_class::reset_num_threads();
+
+   fc::asio::default_io_service_scope::set_num_threads(12);
 
    my_io_class my_class;
 
@@ -42,7 +46,7 @@ BOOST_AUTO_TEST_CASE( number_threads_test )
 BOOST_AUTO_TEST_CASE( default_number_threads_test )
 {
    // to erase leftovers from previous tests
-   fc::asio::default_io_service_scope::set_default_num_threads(0);
+   my_io_class::reset_num_threads();
 
    my_io_class my_class;
 

--- a/tests/io/tcp_test.cpp
+++ b/tests/io/tcp_test.cpp
@@ -1,6 +1,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <fc/network/tcp_socket.hpp>
+#include <fc/asio.hpp>
 
 BOOST_AUTO_TEST_SUITE(tcp_tests)
 
@@ -12,6 +13,42 @@ BOOST_AUTO_TEST_SUITE(tcp_tests)
 BOOST_AUTO_TEST_CASE(tcpconstructor_test)
 {
    fc::tcp_socket socket;
+}
+
+class my_io_class : public fc::asio::default_io_service_scope
+{
+public:
+   int16_t get_num_threads()
+   {
+      return get_default_num_threads();
+   }
+};
+
+/***
+ * Test the control of number of threads from outside
+ */
+BOOST_AUTO_TEST_CASE( number_threads_test )
+{
+   fc::asio::default_io_service_scope::set_default_num_threads(12);
+
+   my_io_class my_class;
+
+   BOOST_CHECK_EQUAL( 12, my_class.get_num_threads() );
+}
+
+/***
+ * Test the control of number of threads from outside
+ */
+BOOST_AUTO_TEST_CASE( default_number_threads_test )
+{
+   // to erase leftovers from previous tests
+   fc::asio::default_io_service_scope::set_default_num_threads(0);
+
+   my_io_class my_class;
+
+   fc::asio::default_io_service();
+
+   BOOST_CHECK( my_class.get_num_threads() > 1 );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is the bitshares-fc part of https://github.com/bitshares/bitshares-core/issues/878

This PR permits the configuration of the number of IO threads by calling a static method prior to calling the constructor of ``default_io_service_scope``. 

It is assumed that during application startup, if the user passes a parameter, this value will be used
during the construction of the ``default_io_service_scope`` object.

If the number of threads is not set, the default is set to either ``std::thread::hardware_concurrency()`` or 2, whichever is greater.

The ``default_io_service_scope`` object serves as a singleton when ``default_io_service()`` is called. Therefore, setting the number of threads after the singleton is constructed will not produce the desired result, as the default specified in the above paragraph will have already been used.

Prior to this change, the number of threads was hard-coded to 8. After this change, if the user does not add the new parameter, they will be using only 2 threads for IO. Perhaps the default should remain 8? This will potentially slow down machines with low cpu counts (as may be the case now), but will not degrade performance for users who upgrade and do not adjust their parameters.

This change required the moving of the ``default_io_service_scope`` class definition into the ``asio.hpp`` header file. This is not ideal, but is required to provide the option to set the default number of threads. I am happy to entertain other ideas that may provide a cleaner interface. One idea I thought about:
- Call default_io_service() with a parameter on start up. We could then put the class definition back in asio.cpp, but would have to start the default_io_service earlier than we do now.