### PR TITLE
Add parameterized constructor (part of Issue 762)

### DIFF
--- a/include/fc/bloom_filter.hpp
+++ b/include/fc/bloom_filter.hpp
@@ -57,6 +57,20 @@ public:
      random_seed(0xA5A5A5A55A5A5A5AULL)
    {}
 
+   bloom_parameters(unsigned long long int projected_element_count,
+         double false_positive_probability,
+         unsigned long long int maximum_size) :
+            minimum_size(1),
+            maximum_size(maximum_size),
+            minimum_number_of_hashes(1),
+            maximum_number_of_hashes(std::numeric_limits<unsigned int>::max()),
+            projected_element_count(projected_element_count),
+            false_positive_probability(false_positive_probability),
+            random_seed(0xA5A5A5A55A5A5A5AULL)
+   {
+      compute_optimal_parameters();
+   }
+
    virtual ~bloom_parameters()
    {}
 


### PR DESCRIPTION
As part of refactoring for https://github.com/bitshares/bitshares-core/issues/762, the bloom filter parameters were being set to the same values each time the bloom filter was being reset. To avoid this unneeded reset, a constructor was added that permits the values to be set when the static is instantiated. 