### PR TITLE
unsigned_int unpacking

### DIFF
--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -195,7 +195,7 @@ namespace fc {
           s.get(b);
           v |= uint32_t(uint8_t(b) & 0x7f) << by;
           by += 7;
-      } while( uint8_t(b) & 0x80 );
+      } while( uint8_t(b) & 0x80 && by < 32);
       vi.value = static_cast<uint32_t>(v);
     }
 


### PR DESCRIPTION
https://github.com/bitshares/bitshares-core/issues/993

"varint decoding could over-shift a 32bit value, now it doesn't"