### PR TITLE
adjust asserts in fc/crypto

### DIFF
--- a/src/crypto/elliptic_common.cpp
+++ b/src/crypto/elliptic_common.cpp
@@ -140,7 +140,7 @@ namespace fc { namespace ecc {
     std::string public_key::to_base58( const public_key_data &key )
     {
       uint32_t check = (uint32_t)sha256::hash(key.data, sizeof(key))._hash[0];
-      assert(key.size() + sizeof(check) == 37);
+      static_assert(sizeof(key) + sizeof(check) == 37, "Elliptic public key size (or its hash) is incorrect");
       array<char, 37> data;
       memcpy(data.data, key.begin(), key.size());
       memcpy(data.begin() + key.size(), (const char*)&check, sizeof(check));
@@ -192,7 +192,7 @@ namespace fc { namespace ecc {
         BN_mod(secexp, secexp, order, ctx);
 
         fc::sha256 secret;
-        assert(BN_num_bytes(secexp) <= int64_t(sizeof(secret)));
+        FC_ASSERT(BN_num_bytes(secexp) <= int64_t(sizeof(secret)));
         auto shift = sizeof(secret) - BN_num_bytes(secexp);
         BN_bn2bin(secexp, ((unsigned char*)&secret)+shift);
         return regenerate( secret );

--- a/src/crypto/pke.cpp
+++ b/src/crypto/pke.cpp
@@ -75,13 +75,13 @@ namespace fc {
 
     bool public_key::verify( const sha1& digest, const signature& sig )const
     {
-       assert( sig.size() == 2048/8 );
+       static_assert( sig.size() == 2048/8, "Invalid signature size" );
        return 0 != RSA_verify( NID_sha1, (const uint8_t*)&digest, 20,
                                (uint8_t*)sig.data(), 2048/8, my->rsa );
     }
     bool public_key::verify( const sha256& digest, const signature& sig )const
     {
-       assert( sig.size() == 2048/8 );
+       static_assert( sig.size() == 2048/8, "Invalid signature size" );
        return 0 != RSA_verify( NID_sha256, (const uint8_t*)&digest, 32,
                                (uint8_t*)sig.data(), 2048/8, my->rsa );
     }


### PR DESCRIPTION
Issue https://github.com/bitshares/bitshares-core/issues/992

Adjusted some asserts in the fc/crypto area. Some should have been static_assert or FC_ASSERT.

The impact of the change from assert to static_assert is minor (we can catch them at compile time, so why not?). 

The 1 switch from assert to FC_ASSERT in elliptic_common.cpp is a bit more impactful. Please consider the side effects as you do your review.

Hat tip to the EOS folks. More information: https://github.com/EOSIO/eos/pull/3560