### PR TITLE
Added protection to collection sizes with FC_ASSERTs

### DIFF
--- a/include/fc/container/flat.hpp
+++ b/include/fc/container/flat.hpp
@@ -10,6 +10,7 @@ namespace fc {
        template<typename Stream, typename T>
        inline void pack( Stream& s, const flat_set<T>& value, uint32_t _max_depth ) {
          FC_ASSERT( _max_depth > 0 );
+         FC_ASSERT( value.size() <= MAX_NUM_ARRAY_ELEMENTS );
          --_max_depth;
          pack( s, unsigned_int((uint32_t)value.size()), _max_depth );
          auto itr = value.begin();
@@ -24,8 +25,8 @@ namespace fc {
          FC_ASSERT( _max_depth > 0 );
          --_max_depth;
          unsigned_int size; unpack( s, size, _max_depth );
+         FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
          value.clear();
-         FC_ASSERT( size.value*sizeof(T) < MAX_ARRAY_ALLOC_SIZE );
          value.reserve(size.value);
          for( uint32_t i = 0; i < size.value; ++i )
          {
@@ -37,6 +38,7 @@ namespace fc {
        template<typename Stream, typename K, typename... V>
        inline void pack( Stream& s, const flat_map<K,V...>& value, uint32_t _max_depth ) {
          FC_ASSERT( _max_depth > 0 );
+         FC_ASSERT( value.size() <= MAX_NUM_ARRAY_ELEMENTS );
          --_max_depth;
          pack( s, unsigned_int((uint32_t)value.size()), _max_depth );
          auto itr = value.begin();
@@ -52,8 +54,8 @@ namespace fc {
          FC_ASSERT( _max_depth > 0 );
          --_max_depth;
          unsigned_int size; unpack( s, size, _max_depth );
+         FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
          value.clear();
-         FC_ASSERT( size.value*(sizeof(K)+sizeof(V)) < MAX_ARRAY_ALLOC_SIZE );
          value.reserve(size.value);
          for( uint32_t i = 0; i < size.value; ++i )
          {

--- a/include/fc/io/raw_fwd.hpp
+++ b/include/fc/io/raw_fwd.hpp
@@ -12,7 +12,8 @@
 #include <unordered_map>
 #include <set>
 
-#define MAX_ARRAY_ALLOC_SIZE (1024*1024*10)
+#define MAX_NUM_ARRAY_ELEMENTS (1024*1024)
+#define MAX_SIZE_OF_BYTE_ARRAYS (20*1024*1024)
 
 namespace fc {
    class time_point;


### PR DESCRIPTION
This is a PR for the bitshares-fc side of issue https://github.com/bitshares/bitshares-core/issues/995

The #define was split in two to make these FC_ASSERTs easier.

Please note that these were not added to the pack/unpack methods for bip::vector<T,A>. I believe they should be, but want to wait for confirmation from others.