### PR TITLE
Add header

### DIFF
--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -2,6 +2,7 @@
 // A stacktrace handler for bitshares
 //
 #include <ostream>
+#include <boost/version.hpp>
 
 // only include stacktrace stuff if boost >= 1.65
 #if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65


### PR DESCRIPTION
This is a simple change to enable boost::stacktrace correctly.

Previously, the BOOST_VERSION macro was not within stacktrace.o, as no boost headers were included. This PR simply includes boost/version.hpp so that the macro is there, and the correct code is run.