### PR TITLE
Get around boost 1.67 boost::filesystem::copy null pointer dereferencing issue

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -243,6 +243,11 @@ namespace fc {
      try {
          boost::system::error_code ec;
          boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t), ec );
+         if( ec )
+         {
+            FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}:${value}",
+                      ("srcfile",f)("dstfile",t)("reason",ec.category().name())("value",ec.value()) );
+         }
      } catch ( boost::system::system_error& e ) {
      	FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}",
 	         ("srcfile",f)("dstfile",t)("reason",e.what() ) );

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -241,7 +241,8 @@ namespace fc {
   void remove_all( const path& p ) { boost::filesystem::remove_all(p); }
   void copy( const path& f, const path& t ) { 
      try {
-  	    boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t) ); 
+         boost::system::error_code ec;
+         boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t), ec );
      } catch ( boost::system::system_error& e ) {
      	FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}",
 	         ("srcfile",f)("dstfile",t)("reason",e.what() ) );

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -245,12 +245,12 @@ namespace fc {
          boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t), ec );
          if( ec )
          {
-            FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}:${value}",
-                      ("srcfile",f)("dstfile",t)("reason",ec.category().name())("value",ec.value()) );
+            FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${code} : ${message}",
+                      ("srcfile",f)("dstfile",t)("code",ec.value())("message",ec.message()) );
          }
      } catch ( boost::system::system_error& e ) {
      	FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}",
-	         ("srcfile",f)("dstfile",t)("reason",e.what() ) );
+	         ("srcfile",f)("dstfile",t)("reason",std::string(e.what()) ) );
      } catch ( ... ) {
      	FC_THROW( "Copy from ${srcfile} to ${dstfile} failed",
 	         ("srcfile",f)("dstfile",t)("inner", fc::except_str() ) );
@@ -264,7 +264,7 @@ namespace fc {
     catch ( boost::system::system_error& e )
     {
       FC_THROW( "Resize file '${f}' to size ${s} failed: ${reason}",
-                ("f",f)("s",t)( "reason", e.what() ) );
+                ("f",f)("s",t)( "reason", std::string(e.what()) ) );
     } 
     catch ( ... ) 
     {
@@ -310,7 +310,7 @@ namespace fc {
          } catch ( fc::exception& e ) {
              FC_RETHROW_EXCEPTION( e, error,
                    "Rename from ${srcfile} to ${dstfile} failed due to ${reason}, trying to copy then remove",
-                   ("srcfile",f)("dstfile",t)("reason",er.what()) );
+                   ("srcfile",f)("dstfile",t)("reason",std::string(er.what())) );
          }
      } catch ( ... ) {
      	FC_THROW( "Rename from ${srcfile} to ${dstfile} failed",

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -303,13 +303,14 @@ namespace fc {
   void rename( const path& f, const path& t ) { 
      try {
   	    boost::filesystem::rename( boost::filesystem::path(f), boost::filesystem::path(t) ); 
-     } catch ( boost::system::system_error& ) {
-         try{
-             boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t) ); 
-             boost::filesystem::remove( boost::filesystem::path(f)); 
-         } catch ( boost::system::system_error& e ) {
-             FC_THROW( "Rename from ${srcfile} to ${dstfile} failed because ${reason}",
-                     ("srcfile",f)("dstfile",t)("reason",e.what() ) );
+     } catch ( boost::system::system_error& er ) {
+         try {
+            copy( f, t );
+            remove( f );
+         } catch ( fc::exception& e ) {
+             FC_RETHROW_EXCEPTION( e, error,
+                   "Rename from ${srcfile} to ${dstfile} failed due to ${reason}, trying to copy then remove",
+                   ("srcfile",f)("dstfile",t)("reason",er.what()) );
          }
      } catch ( ... ) {
      	FC_THROW( "Rename from ${srcfile} to ${dstfile} failed",


### PR DESCRIPTION
Replaces #42.

Fixes a cli_wallet crash when trying to import private key with `import_key` command.