### PR TITLE
Missing FC Typenames (core issue #1217)

### DIFF
--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -7,6 +7,7 @@
 
 #include <fc/string.hpp>
 #include <fc/optional.hpp>
+#include <fc/smart_ref_fwd.hpp>
 
 #include <fc/container/flat_fwd.hpp>
 #include <fc/container/deque_fwd.hpp>
@@ -86,10 +87,19 @@ namespace fc {
          return n.c_str();
       }
   }; 
+  template<typename T> struct get_typename< fc::smart_ref<T> >
+  {
+     static const char* name()
+     {
+        return (std::string("fc::smart_ref<") + get_typename<T>::name() + std::string(">")).c_str();
+     }
+  };
 
   struct signed_int;
   struct unsigned_int;
+  struct variant_object;
   template<> struct get_typename<signed_int>   { static const char* name()   { return "signed_int";   } };
   template<> struct get_typename<unsigned_int>   { static const char* name()   { return "unsigned_int";   } };
+  template<> struct get_typename<variant_object>   { static const char* name()   { return "fc::variant_object";   } };
 
 }

--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -91,7 +91,8 @@ namespace fc {
   {
      static const char* name()
      {
-        return (std::string("fc::smart_ref<") + get_typename<T>::name() + std::string(">")).c_str();
+        static std::string n = std::string("fc::smart_ref<") + get_typename<T>::name() + std::string(">");
+        return n.c_str();
      }
   };
 

--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <map>
+#include <set>
 #include <vector>
 
 #include <fc/string.hpp>
@@ -69,6 +70,22 @@ namespace fc {
          return n.c_str();  
      } 
   };
+  template<typename E> struct get_typename< std::set<E> >
+  {
+     static const char* name()
+     {
+        static std::string n = std::string("std::set<") + std::string(get_typename<E>::name()) + std::string(">");
+        return n.c_str();
+     }
+  };
+ template<typename A, typename B> struct get_typename< std::pair<A,B> >
+  {
+      static const char* name()
+      {
+         static std::string n = std::string("std::pair<") + get_typename<A>::name() + "," + get_typename<B>::name() + ">";
+         return n.c_str();
+      }
+  }; 
 
   struct signed_int;
   struct unsigned_int;

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -382,5 +382,46 @@ public:
       s.visit( to_static_variant(ar[1], max_depth - 1) );
    }
 
-  template<typename... T> struct get_typename  { static const char* name()   { return typeid(static_variant<T...>).name();   } };
+   template< typename... T > struct get_comma_separated_typenames;
+
+   template<>
+   struct get_comma_separated_typenames<>
+   {
+      static const char* names() { return ""; }
+   };
+
+   template< typename T >
+   struct get_comma_separated_typenames<T>
+   {
+      static const char* names()
+      {
+         static const std::string n = get_typename<T>::name();
+         return n.c_str();
+      }
+   };
+
+   template< typename T, typename... Ts >
+   struct get_comma_separated_typenames<T, Ts...>
+   {
+      static const char* names()
+      {
+         static const std::string n =
+            std::string( get_typename<T>::name() )+","+
+            std::string( get_comma_separated_typenames< Ts... >::names() );
+         return n.c_str();
+      }
+   };
+
+   template< typename... T >
+   struct get_typename< static_variant< T... > >
+   {
+      static const char* name()
+      {
+         static const std::string n = std::string( "fc::static_variant<" )
+            + get_comma_separated_typenames<T...>::names()
+            + ">";
+         return n.c_str();
+      }
+   };
+
 } // namespace fc


### PR DESCRIPTION
This is the fc portion of https://github.com/bitshares/bitshares-core/issues/1217

Prior get_typename was generating classes on many unnecessary classes. This modification correctly generates code for only the classes necessary.