### PR TITLE
Generalize flat_set serialization templates to allow different sorting and/or allocators

### DIFF
--- a/include/fc/container/flat.hpp
+++ b/include/fc/container/flat.hpp
@@ -7,8 +7,8 @@
 
 namespace fc {
    namespace raw {
-       template<typename Stream, typename T>
-       inline void pack( Stream& s, const flat_set<T>& value, uint32_t _max_depth ) {
+       template<typename Stream, typename T, typename... A>
+       inline void pack( Stream& s, const flat_set<T, A...>& value, uint32_t _max_depth ) {
          FC_ASSERT( _max_depth > 0 );
          --_max_depth;
          pack( s, unsigned_int(value.size()), _max_depth );
@@ -19,8 +19,8 @@ namespace fc {
            ++itr;
          }
        }
-       template<typename Stream, typename T>
-       inline void unpack( Stream& s, flat_set<T>& value, uint32_t _max_depth ) {
+       template<typename Stream, typename T, typename... A>
+       inline void unpack( Stream& s, flat_set<T, A...>& value, uint32_t _max_depth ) {
          FC_ASSERT( _max_depth > 0 );
          --_max_depth;
          unsigned_int size; unpack( s, size, _max_depth );
@@ -98,8 +98,8 @@ namespace fc {
    } // namespace raw
 
 
-   template<typename T>
-   void to_variant( const flat_set<T>& var, variant& vo, uint32_t _max_depth )
+   template<typename T, typename... A>
+   void to_variant( const flat_set<T, A...>& var, variant& vo, uint32_t _max_depth )
    {
        FC_ASSERT( _max_depth > 0 );
       --_max_depth;
@@ -109,8 +109,8 @@ namespace fc {
           vars[i++] = variant( item, _max_depth );
        vo = vars;
    }
-   template<typename T>
-   void from_variant( const variant& var, flat_set<T>& vo, uint32_t _max_depth )
+   template<typename T, typename... A>
+   void from_variant( const variant& var, flat_set<T, A...>& vo, uint32_t _max_depth )
    {
       FC_ASSERT( _max_depth > 0 );
       --_max_depth;

--- a/include/fc/container/flat_fwd.hpp
+++ b/include/fc/container/flat_fwd.hpp
@@ -11,10 +11,10 @@ namespace fc {
    namespace bip = boost::interprocess;
 
    namespace raw {
-       template<typename Stream, typename T>
-       void pack( Stream& s, const flat_set<T>& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
-       template<typename Stream, typename T>
-       void unpack( Stream& s, flat_set<T>& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+       template<typename Stream, typename T, typename... A>
+       void pack( Stream& s, const flat_set<T, A...>& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
+       template<typename Stream, typename T, typename... A>
+       void unpack( Stream& s, flat_set<T, A...>& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
        template<typename Stream, typename K, typename... V>
        void pack( Stream& s, const flat_map<K,V...>& value, uint32_t _max_depth=FC_PACK_MAX_DEPTH );
        template<typename Stream, typename K, typename V, typename... A>

--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -129,10 +129,10 @@ namespace fc
    template<typename T>
    void from_variant( const variant& var, std::deque<T>& vo, uint32_t max_depth );
 
-   template<typename T>
-   void to_variant( const fc::flat_set<T>& var,   variant& vo, uint32_t max_depth );
-   template<typename T>
-   void from_variant( const variant& var, fc::flat_set<T>& vo, uint32_t max_depth );
+   template<typename T, typename... A>
+   void to_variant( const fc::flat_set<T, A...>& var,   variant& vo, uint32_t max_depth );
+   template<typename T, typename... A>
+   void from_variant( const variant& var, fc::flat_set<T, A...>& vo, uint32_t max_depth );
 
    template<typename T>
    void to_variant( const std::set<T>& var,  variant& vo,  uint32_t max_depth );


### PR DESCRIPTION
Will be helpful in replacing more ``flat_set<public_key_type>`` with more efficient sorting.