### PR TITLE
Initialize max_object_depth in appender config

### DIFF
--- a/include/fc/log/file_appender.hpp
+++ b/include/fc/log/file_appender.hpp
@@ -18,7 +18,7 @@ class file_appender : public appender {
             bool                               rotate = false;
             microseconds                       rotation_interval;
             microseconds                       rotation_limit;
-            uint32_t                           max_object_depth;
+            uint32_t                           max_object_depth = FC_MAX_LOG_OBJECT_DEPTH;
          };
          file_appender( const variant& args );
          ~file_appender();

--- a/include/fc/log/gelf_appender.hpp
+++ b/include/fc/log/gelf_appender.hpp
@@ -15,7 +15,7 @@ namespace fc
     {
       string endpoint = "127.0.0.1:12201";
       string host = "fc"; // the name of the host, source or application that sent this message (just passed through to GELF server)
-      uint32_t max_object_depth;
+      uint32_t max_object_depth = FC_MAX_LOG_OBJECT_DEPTH;
     };
 
     gelf_appender(const variant& args);

--- a/src/log/file_appender.cpp
+++ b/src/log/file_appender.cpp
@@ -144,9 +144,7 @@ namespace fc {
 
    file_appender::file_appender( const variant& args ) :
      my( new impl( args.as<config>( FC_MAX_LOG_OBJECT_DEPTH ) ) )
-   {
-      
-   }
+   {}
 
    file_appender::~file_appender(){}
 


### PR DESCRIPTION
by setting a default value, for file_appender and gelf_appender.
For issue https://github.com/bitshares/bitshares-core/issues/1392
