### PR TITLE
Fix Compiler Warnings

### DIFF
--- a/include/fc/crypto/rand.hpp
+++ b/include/fc/crypto/rand.hpp
@@ -4,5 +4,4 @@ namespace fc {
 
   /* provides access to the OpenSSL random number generator */
   void rand_bytes(char* buf, int count);
-  void rand_pseudo_bytes(char* buf, int count);
 } // namespace fc 

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -429,7 +429,7 @@ openssl_thread_config::openssl_thread_config()
 }
 openssl_thread_config::~openssl_thread_config()
 {
-  if (CRYPTO_get_id_callback() != NULL && CRYPTO_get_id_callback() == &get_thread_id)
+  if (CRYPTO_get_id_callback() == &get_thread_id)
   {
     CRYPTO_set_id_callback(NULL);
     CRYPTO_set_locking_callback(NULL);

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -429,7 +429,7 @@ openssl_thread_config::openssl_thread_config()
 }
 openssl_thread_config::~openssl_thread_config()
 {
-  if (CRYPTO_get_id_callback() == &get_thread_id)
+  if (CRYPTO_get_id_callback() != NULL && CRYPTO_get_id_callback() == &get_thread_id)
   {
     CRYPTO_set_id_callback(NULL);
     CRYPTO_set_locking_callback(NULL);

--- a/src/crypto/openssl.cpp
+++ b/src/crypto/openssl.cpp
@@ -29,8 +29,12 @@ namespace  fc
             putenv((char*)varSetting.c_str());
 #endif
           }
-
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+         // no longer needed as of OpenSSL 1.1
+         // if special initialization is necessary in versions 1.1 and above,
+         // use OPENSSL_init_crypto
           OPENSSL_config(nullptr);
+#endif
        }
 
        ~openssl_scope()

--- a/src/crypto/rand.cpp
+++ b/src/crypto/rand.cpp
@@ -16,14 +16,4 @@ void rand_bytes(char* buf, int count)
     FC_THROW("Error calling OpenSSL's RAND_bytes(): ${code}", ("code", (uint32_t)ERR_get_error()));
 }
 
-void rand_pseudo_bytes(char* buf, int count)
-{
-  static int init = init_openssl();
-  (void)init;
-
-  int result = RAND_pseudo_bytes((unsigned char*)buf, count);
-  if (result == -1)
-    FC_THROW("Error calling OpenSSL's RAND_pseudo_bytes(): ${code}", ("code", (uint32_t)ERR_get_error()));
-}
-
 }  // namespace fc

--- a/tests/crypto/dh_test.cpp
+++ b/tests/crypto/dh_test.cpp
@@ -78,8 +78,8 @@ BOOST_AUTO_TEST_CASE(dh_size_mismatch_test)
 
    BOOST_CHECK( alice.compute_shared_key( bob.pub_key ) );
    BOOST_CHECK( bob.compute_shared_key( alice.pub_key ) );
-   BOOST_CHECK_EQUAL( 15, alice.shared_key.size() );
-   BOOST_CHECK_EQUAL( 15, bob.shared_key.size() );
+   BOOST_CHECK_EQUAL( 15u, alice.shared_key.size() );
+   BOOST_CHECK_EQUAL( 15u, bob.shared_key.size() );
    BOOST_CHECK( !memcmp( alice.shared_key.data(), bob.shared_key.data(), alice.shared_key.size() ) );
 
    BOOST_CHECK_EQUAL( SHARED_KEY, std::string( alice.shared_key.begin(), alice.shared_key.end() ) );

--- a/tests/crypto/rand_test.cpp
+++ b/tests/crypto/rand_test.cpp
@@ -18,13 +18,6 @@ static void check_randomness( const char* buffer, size_t len ) {
         }
     }
     BOOST_CHECK_EQUAL( 8*len, zc + oc );
-    double E = 1 + (zc + oc) / 2.0;
-    double variance = (E - 1) * (E - 2) / (oc + zc - 1);
-    double sigma = sqrt(variance);
-
-    // Next 2 test were removed as it will not always pass
-    //BOOST_CHECK_GT(rc, E - sigma);
-    //BOOST_CHECK_LT(rc, E + sigma);
 }
 
 BOOST_AUTO_TEST_SUITE(fc_crypto)
@@ -33,13 +26,6 @@ BOOST_AUTO_TEST_CASE(rand_test)
 {
     char buffer[128];
     fc::rand_bytes( buffer, sizeof(buffer) );
-    check_randomness( buffer, sizeof(buffer) );
-}
-
-BOOST_AUTO_TEST_CASE(pseudo_rand_test)
-{
-    char buffer[10013];
-    fc::rand_pseudo_bytes( buffer, sizeof(buffer) );
     check_randomness( buffer, sizeof(buffer) );
 }
 

--- a/tests/io/json_tests.cpp
+++ b/tests/io/json_tests.cpp
@@ -189,11 +189,11 @@ static void test_recursive( const fc::variant& v )
    fc::json::save_to_file( v, file.path(), false );
 
    fc::variants list = fc::json::variants_from_string( json );
-   BOOST_CHECK_EQUAL( 1, list.size() );
+   BOOST_CHECK_EQUAL( 1u, list.size() );
    BOOST_CHECK( equal( v, list[0] ) );
 
    list = fc::json::variants_from_string( pretty );
-   BOOST_CHECK_EQUAL( 1, list.size() );
+   BOOST_CHECK_EQUAL( 1u, list.size() );
    BOOST_CHECK( equal( v, list[0] ) );
 
    BOOST_CHECK( equal( v, fc::json::from_string( json + " " ) ) );

--- a/tests/io/stream_tests.cpp
+++ b/tests/io/stream_tests.cpp
@@ -22,17 +22,17 @@ BOOST_AUTO_TEST_CASE(stringstream_test)
    *buf = 'w';
    in2.writesome( buf, 1, 0 );
 
-   BOOST_CHECK_EQUAL( 3, in1.readsome( buf, 3, 0 ) );
-   BOOST_CHECK_EQUAL( 3, out.writesome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, in1.readsome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, out.writesome( buf, 3, 0 ) );
    BOOST_CHECK_EQUAL( 'l', in1.peek() );
-   BOOST_CHECK_EQUAL( 3, in1.readsome( buf, 4, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, in1.readsome( buf, 4, 0 ) );
    BOOST_CHECK_EQUAL( '\0', (&(*buf))[2] );
-   BOOST_CHECK_EQUAL( 2, out.writesome( buf, 2, 0 ) );
+   BOOST_CHECK_EQUAL( 2u, out.writesome( buf, 2, 0 ) );
    *buf = ' ';
    out.writesome( buf, 1, 0 );
    BOOST_CHECK_THROW( in1.readsome( buf, 3, 0 ), fc::eof_exception );
-   BOOST_CHECK_EQUAL( 5, in2.readsome( buf, 6, 0 ) );
-   BOOST_CHECK_EQUAL( 5, out.writesome( buf, 5, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, in2.readsome( buf, 6, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, out.writesome( buf, 5, 0 ) );
    BOOST_CHECK_THROW( in2.readsome( buf, 3, 0 ), fc::eof_exception );
 
    BOOST_CHECK_EQUAL( "Hello world", out.str() );
@@ -57,17 +57,17 @@ BOOST_AUTO_TEST_CASE(buffered_stringstream_test)
    *buf = 'w';
    in2->writesome( buf, 1, 0 );
 
-   BOOST_CHECK_EQUAL( 3, bin1.readsome( buf, 3, 0 ) );
-   BOOST_CHECK_EQUAL( 3, bout.writesome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, bin1.readsome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, bout.writesome( buf, 3, 0 ) );
    BOOST_CHECK_EQUAL( 'l', bin1.peek() );
-   BOOST_CHECK_EQUAL( 3, bin1.readsome( buf, 4, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, bin1.readsome( buf, 4, 0 ) );
    BOOST_CHECK_EQUAL( '\0', (&(*buf))[2] );
-   BOOST_CHECK_EQUAL( 2, bout.writesome( buf, 2, 0 ) );
+   BOOST_CHECK_EQUAL( 2u, bout.writesome( buf, 2, 0 ) );
    *buf = ' ';
    bout.writesome( buf, 1, 0 );
    BOOST_CHECK_THROW( bin1.readsome( buf, 3, 0 ), fc::eof_exception );
-   BOOST_CHECK_EQUAL( 5, bin2.readsome( buf, 6, 0 ) );
-   BOOST_CHECK_EQUAL( 5, bout.writesome( buf, 5, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, bin2.readsome( buf, 6, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, bout.writesome( buf, 5, 0 ) );
    BOOST_CHECK_THROW( bin2.readsome( buf, 3, 0 ), fc::eof_exception );
 
    bout.flush();
@@ -99,24 +99,24 @@ BOOST_AUTO_TEST_CASE(fstream_test)
    fc::ofstream out( outf.path() );
 
    std::shared_ptr<char> buf( new char[15], [](char* p){ delete[] p; } );
-   BOOST_CHECK_EQUAL( 3, in1.readsome( buf, 3, 0 ) );
-   BOOST_CHECK_EQUAL( 3, out.writesome( buf, 3, 0 ) );
-   BOOST_CHECK_EQUAL( 3, in1.readsome( buf, 4, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, in1.readsome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, out.writesome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, in1.readsome( buf, 4, 0 ) );
    BOOST_CHECK_EQUAL( '\0', (&(*buf))[2] );
-   BOOST_CHECK_EQUAL( 2, out.writesome( buf, 2, 0 ) );
+   BOOST_CHECK_EQUAL( 2u, out.writesome( buf, 2, 0 ) );
    *buf = ' ';
    out.writesome( buf, 1, 0 );
    BOOST_CHECK_THROW( in1.readsome( buf, 3, 0 ), fc::eof_exception );
-   BOOST_CHECK_EQUAL( 5, in2.readsome( buf, 6, 0 ) );
-   BOOST_CHECK_EQUAL( 5, out.writesome( buf, 5, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, in2.readsome( buf, 6, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, out.writesome( buf, 5, 0 ) );
    BOOST_CHECK_THROW( in2.readsome( buf, 3, 0 ), fc::eof_exception );
 
    {
       out.flush();
       std::fstream test( outf.path().to_native_ansi_path(), std::fstream::in );
-      BOOST_CHECK_EQUAL( 11, test.readsome( (&(*buf)), 11 ) );
+      BOOST_CHECK_EQUAL( 11u, test.readsome( (&(*buf)), 11 ) );
       BOOST_CHECK_EQUAL( "Hello world", std::string( (&(*buf)), 11 ) );
-      BOOST_CHECK_EQUAL( 0, test.readsome( (&(*buf)), 11 ) );
+      BOOST_CHECK_EQUAL( 0u, test.readsome( (&(*buf)), 11 ) );
       test.close();
    }
 
@@ -152,25 +152,25 @@ BOOST_AUTO_TEST_CASE(buffered_fstream_test)
 
    std::shared_ptr<char> buf( new char[15], [](char* p){ delete[] p; } );
 
-   BOOST_CHECK_EQUAL( 3, bin1.readsome( buf, 3, 0 ) );
-   BOOST_CHECK_EQUAL( 3, bout.writesome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, bin1.readsome( buf, 3, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, bout.writesome( buf, 3, 0 ) );
    BOOST_CHECK_EQUAL( 'l', bin1.peek() );
-   BOOST_CHECK_EQUAL( 3, bin1.readsome( buf, 4, 0 ) );
+   BOOST_CHECK_EQUAL( 3u, bin1.readsome( buf, 4, 0 ) );
    BOOST_CHECK_EQUAL( '\0', (&(*buf))[2] );
-   BOOST_CHECK_EQUAL( 2, bout.writesome( buf, 2, 0 ) );
+   BOOST_CHECK_EQUAL( 2u, bout.writesome( buf, 2, 0 ) );
    *buf = ' ';
    bout.writesome( buf, 1, 0 );
    BOOST_CHECK_THROW( bin1.readsome( buf, 3, 0 ), fc::eof_exception );
-   BOOST_CHECK_EQUAL( 5, bin2.readsome( buf, 6, 0 ) );
-   BOOST_CHECK_EQUAL( 5, bout.writesome( buf, 5, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, bin2.readsome( buf, 6, 0 ) );
+   BOOST_CHECK_EQUAL( 5u, bout.writesome( buf, 5, 0 ) );
    BOOST_CHECK_THROW( bin2.readsome( buf, 3, 0 ), fc::eof_exception );
 
    {
       bout.flush();
       std::fstream test( outf.path().to_native_ansi_path(), std::fstream::in );
-      BOOST_CHECK_EQUAL( 11, test.readsome( (&(*buf)), 11 ) );
+      BOOST_CHECK_EQUAL( 11u, test.readsome( (&(*buf)), 11 ) );
       BOOST_CHECK_EQUAL( "Hello world", std::string( (&(*buf)), 11 ) );
-      BOOST_CHECK_EQUAL( 0, test.readsome( (&(*buf)), 11 ) );
+      BOOST_CHECK_EQUAL( 0u, test.readsome( (&(*buf)), 11 ) );
       test.close();
    }
 }

--- a/tests/io/varint_tests.cpp
+++ b/tests/io/varint_tests.cpp
@@ -64,7 +64,7 @@ static const std::vector<fc::unsigned_int> TEST_U = {
 BOOST_AUTO_TEST_CASE( test_unsigned )
 { try {
    const std::vector<char> packed_u = fc::raw::pack<std::vector<fc::unsigned_int>>( TEST_U, 3 );
-   BOOST_CHECK_EQUAL( UINT_LENGTH, packed_u.size() );
+   BOOST_CHECK_EQUAL( UINT_LENGTH, (int)packed_u.size() );
    BOOST_CHECK_EQUAL( EXPECTED_UINTS, std::string( packed_u.data(), packed_u.size() ) );
    std::vector<fc::unsigned_int> unpacked_u;
    fc::raw::unpack<std::vector<fc::unsigned_int>>( packed_u, unpacked_u, 3 );


### PR DESCRIPTION
Fix for https://github.com/bitshares/bitshares-core/issues/1383

Several compiler warnings have appeared due to upgrades of compilers and OpenSSL.

Synopsis of changes:

rand.hpp - OpenSSL's CRYPTO_pseudo_random_bytes has been deprecated. This is used in only 1 place in Bitshares, and should be replaced with fc::rand_bytes (net/node.cpp).

openssl.cpp - OPENSSL_config(nullptr) is no longer needed with OpenSSL 1.1. It has been replaced with an init function that is automatically called with defaults when needed.

The rest of the changes were simply to squelch compiler warnings and SHOULD NOT change code logic.