### PR TITLE
Memory optimization of static_variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ set( fc_sources
      src/variant.cpp
      src/exception.cpp
      src/variant_object.cpp
+     src/static_variant.cpp
      src/thread/thread.cpp
      src/thread/thread_specific.cpp
      src/thread/future.cpp

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -1,4 +1,4 @@
-/** This source adapted from https://github.com/kmicklas/variadic-static_variant
+/** This source adapted from https://github.com/kmicklas/variadic-static_variant. Now available at https://github.com/kmicklas/variadic-variant.
  *
  * Copyright (C) 2013 Kenneth Micklas
  *
@@ -176,6 +176,41 @@ struct type_info<> {
     static const size_t size = 0;
 };
 
+template<typename TTag>
+size_t size( TTag )
+{
+    return 0;
+}
+
+template<typename TTag, typename A, typename...Ts>
+size_t size( TTag tag )
+{
+    if (tag <= 0)
+    {
+        return sizeof(A);
+    }
+
+    return size<TTag, Ts...>( --tag );
+}
+
+
+class dynamic_storage
+{
+    char* storage;
+public:
+    dynamic_storage();
+
+    ~dynamic_storage();
+
+    void* data() const;
+
+    void alloc( size_t size );
+
+    void release();
+};
+
+
+
 } // namespace impl
 
 template<typename Visitor,typename Data>
@@ -213,40 +248,57 @@ class static_variant {
     static_assert(impl::type_info<Types...>::no_reference_types, "Reference types are not permitted in static_variant.");
     static_assert(impl::type_info<Types...>::no_duplicates, "static_variant type arguments contain duplicate types.");
 
+    template<typename X>
+    using type_in_typelist = typename std::enable_if<impl::position<X, Types...>::pos != -1, X>::type; // type is in typelist of static_variant.
+
     using tag_type = int64_t;
     tag_type _tag;
-    char storage[impl::type_info<Types...>::size];
+    impl::dynamic_storage storage;
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     void init(const X& x) {
         _tag = impl::position<X, Types...>::pos;
-        new(storage) X(x);
+        storage.alloc( sizeof(X) );
+        new(storage.data()) X(x);
     }
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     void init(X&& x) {
         _tag = impl::position<X, Types...>::pos;
-        new(storage) X( std::move(x) );
+        storage.alloc( sizeof(X) );
+        new(storage.data()) X( std::move(x) );
     }
+
+    void init(tag_type tag)
+    {
+        FC_ASSERT( tag >= 0 );
+        FC_ASSERT( tag < count() );
+        _tag = tag;
+        storage.alloc( impl::size<tag_type, Types...>( tag ) );
+        impl::storage_ops<0, Types...>::con(_tag, storage.data());
+    }
+
+    void clean()
+    {
+        impl::storage_ops<0, Types...>::del(_tag, storage.data() );
+        storage.release();
+    }
+
 
     template<typename StaticVariant>
     friend struct impl::copy_construct;
     template<typename StaticVariant>
     friend struct impl::move_construct;
 public:
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     struct tag
     {
-       static_assert(
-         impl::position<X, Types...>::pos != -1,
-         "Type not in static_variant."
-       );
        static const int value = impl::position<X, Types...>::pos;
     };
+
     static_variant()
     {
-       _tag = 0;
-       impl::storage_ops<0, Types...>::con(0, storage);
+        init(0);
     }
 
     template<typename... Other>
@@ -254,6 +306,7 @@ public:
     {
        cpy.visit( impl::copy_construct<static_variant>(*this) );
     }
+
     static_variant( const static_variant& cpy )
     {
        cpy.visit( impl::copy_construct<static_variant>(*this) );
@@ -264,40 +317,32 @@ public:
        mv.visit( impl::move_construct<static_variant>(*this) );
     }
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     static_variant(const X& v) {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
         init(v);
     }
+
     ~static_variant() {
-       impl::storage_ops<0, Types...>::del(_tag, storage);
+       clean();
     }
 
-
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     static_variant& operator=(const X& v) {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
-        this->~static_variant();
+        clean();
         init(v);
         return *this;
     }
     static_variant& operator=( const static_variant& v )
     {
        if( this == &v ) return *this;
-       this->~static_variant();
+       clean();
        v.visit( impl::copy_construct<static_variant>(*this) );
        return *this;
     }
     static_variant& operator=( static_variant&& v )
     {
        if( this == &v ) return *this;
-       this->~static_variant();
+       clean();
        v.visit( impl::move_construct<static_variant>(*this) );
        return *this;
     }
@@ -310,52 +355,40 @@ public:
        return a.which() < b.which();
     }
 
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     X& get() {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
         if(_tag == impl::position<X, Types...>::pos) {
-            void* tmp(storage);
-            return *reinterpret_cast<X*>(tmp);
+            return *reinterpret_cast<X*>(storage.data());
         } else {
             FC_THROW_EXCEPTION( fc::assert_exception, "static_variant does not contain a value of type ${t}", ("t",fc::get_typename<X>::name()) );
-           //     std::string("static_variant does not contain value of type ") + typeid(X).name()
-           // );
         }
     }
-    template<typename X>
+    template<typename X, typename = type_in_typelist<X>>
     const X& get() const {
-        static_assert(
-            impl::position<X, Types...>::pos != -1,
-            "Type not in static_variant."
-        );
         if(_tag == impl::position<X, Types...>::pos) {
-            const void* tmp(storage);
-            return *reinterpret_cast<const X*>(tmp);
+            return *reinterpret_cast<const X*>(storage.data());
         } else {
             FC_THROW_EXCEPTION( fc::assert_exception, "static_variant does not contain a value of type ${t}", ("t",fc::get_typename<X>::name()) );
         }
     }
     template<typename visitor>
     typename visitor::result_type visit(visitor& v) {
-        return visit( _tag, v, (void*) storage );
+        return visit( _tag, v, (void*) storage.data() );
     }
 
     template<typename visitor>
     typename visitor::result_type visit(const visitor& v) {
-        return visit( _tag, v, (void*) storage );
+        return visit( _tag, v, (void*) storage.data() );
     }
 
     template<typename visitor>
     typename visitor::result_type visit(visitor& v)const {
-        return visit( _tag, v, (const void*) storage );
+        return visit( _tag, v, (const void*) storage.data() );
     }
 
     template<typename visitor>
     typename visitor::result_type visit(const visitor& v)const {
-        return visit( _tag, v, (const void*) storage );
+        return visit( _tag, v, (const void*) storage.data() );
     }
 
     template<typename visitor>
@@ -394,9 +427,8 @@ public:
     void set_which( tag_type w ) {
       FC_ASSERT( w >= 0 );
       FC_ASSERT( w < count() );
-      this->~static_variant();
-      _tag = w;
-      impl::storage_ops<0, Types...>::con(_tag, storage);
+      clean();
+      init(w);
     }
 
     tag_type which() const {return _tag;}

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -245,6 +245,7 @@ std::vector<std::function<typename Visitor::result_type(Visitor&,Data)>> init_co
 
 template<typename... Types>
 class static_variant {
+protected:
     static_assert(impl::type_info<Types...>::no_reference_types, "Reference types are not permitted in static_variant.");
     static_assert(impl::type_info<Types...>::no_duplicates, "static_variant type arguments contain duplicate types.");
 
@@ -269,7 +270,7 @@ class static_variant {
         new(storage.data()) X( std::move(x) );
     }
 
-    void init(tag_type tag)
+    void init_from_tag(tag_type tag)
     {
         FC_ASSERT( tag >= 0 );
         FC_ASSERT( tag < count() );
@@ -298,7 +299,7 @@ public:
 
     static_variant()
     {
-        init(0);
+        init_from_tag(0);
     }
 
     template<typename... Other>
@@ -428,7 +429,7 @@ public:
       FC_ASSERT( w >= 0 );
       FC_ASSERT( w < count() );
       clean();
-      init(w);
+      init_from_tag(w);
     }
 
     tag_type which() const {return _tag;}

--- a/src/static_variant.cpp
+++ b/src/static_variant.cpp
@@ -1,0 +1,31 @@
+#include <fc/static_variant.hpp>
+
+
+namespace fc { namespace impl {
+
+dynamic_storage::dynamic_storage() : storage(nullptr) {};
+
+dynamic_storage::~dynamic_storage()
+{
+    release();
+}
+
+void* dynamic_storage::data() const
+{
+    assert( storage != nullptr );
+    return (void*)storage;
+}
+
+void dynamic_storage::alloc( size_t size )
+{
+    release();
+    storage = new char[size];
+}
+
+void dynamic_storage::release()
+{
+    delete [] storage;
+    storage = nullptr;
+}
+
+}}

--- a/src/static_variant.cpp
+++ b/src/static_variant.cpp
@@ -12,7 +12,7 @@ dynamic_storage::~dynamic_storage()
 
 void* dynamic_storage::data() const
 {
-    assert( storage != nullptr );
+    FC_ASSERT( storage != nullptr );
     return (void*)storage;
 }
 

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -46,6 +46,55 @@ FC_REFLECT( fc::test::item, (level)(w) );
 
 BOOST_AUTO_TEST_SUITE(fc_variant_and_log)
 
+BOOST_AUTO_TEST_CASE( types_edge_cases_test )
+{
+   using namespace fc::test;
+
+   class sv : public fc::static_variant<>
+   {
+   public:
+       BOOST_ATTRIBUTE_UNUSED typedef fc::static_variant<>::tag_type tag_type;
+   };
+
+   BOOST_TEST_MESSAGE( "========== Test empty static_variant ==========" );
+
+   BOOST_CHECK_THROW( fc::static_variant<>(), fc::assert_exception );
+
+   BOOST_TEST_MESSAGE( "========== Test static_variant with tag_type ==========" );
+
+   sv::tag_type init_value = 2;
+   fc::static_variant< sv::tag_type, std::string, fc::variant > variant_with_tagtype(init_value);
+
+   BOOST_CHECK_EQUAL( variant_with_tagtype.count(), 3 );
+   BOOST_CHECK_EQUAL( variant_with_tagtype.which(), 0 );
+
+   sv::tag_type current_value = variant_with_tagtype.get<sv::tag_type>();
+   BOOST_CHECK_EQUAL( current_value, init_value );
+   BOOST_CHECK( variant_with_tagtype == init_value );
+
+   for (sv::tag_type i = variant_with_tagtype.count(); i-->0;)
+   {
+      variant_with_tagtype.set_which(i);
+      BOOST_CHECK_EQUAL(variant_with_tagtype.which(), i);
+   }
+
+   BOOST_TEST_MESSAGE( "========== Test static_variant with static_variant ==========" );
+
+   using sv_double = fc::static_variant<double>;
+   using sv_float = fc::static_variant<float>;
+   fc::static_variant< sv_float, std::string, sv_double > variant;
+   sv_float variant_float = 1.5f;
+   variant = variant_float;
+   BOOST_CHECK_EQUAL( variant.which(), 0 );
+   BOOST_CHECK_EQUAL( variant.get<sv_float>().get<float>(), 1.5f );
+
+   sv_double variant_double = 1.0;
+   variant = variant_double;
+   BOOST_CHECK_EQUAL( variant.which() , 2);
+   BOOST_CHECK_EQUAL( variant.get<sv_double>().get<double>(), 1.0 );
+}
+
+
 BOOST_AUTO_TEST_CASE( nested_objects_test )
 { try {
 


### PR DESCRIPTION
In [bitshares/bitshares-core](https://github.com/bitshares/bitshares-core) `operation` is typedef of `static_variant`. As blockchain operations are used everywhere in the database it would be great to reduce the memory footprint of this structure as much as possible.

`static_variant` contains member variable `storage` that is a static array of characters which size is deduced from the largest type of a variant. This means every `operation` in the database is as large as the largest type + 8 bytes for `_tag` + some bytes for memory alignment.

The largest operation is the `account_create_operation` with 424 bytes while the average size of a operation is 110 bytes. *And this operation isn't even a frequently used one*.

I have decided to replace this static array with dynamically allocated storage (`dynamic_storage`).

Here are the results of the optimization:

## Parameters:
*Total block count*: `28387605` 
Important lines in my `config.ini`:
```ini
seed-nodes = []
# partial-operations = 1 // this means partial-operations is 0 (false)
max-ops-per-account = 100
bucket-size = [60,300,900,1800,3600,14400,86400]
history-per-size = 1000
max-order-his-records-per-market = 1000
max-order-his-seconds-per-market = 259200
```
*Input parameters*:
```shell
witness_node --replay-blockchain
```

## Results:

* Original implementation (static allocation):

memory:
```
 Private  +   Shared  =  RAM used       Program
122.0 GiB + 794.0 KiB = 122.0 GiB       witness_node
```
time of the blockchain replay & db reindexing:
```
CPU-seconds in user mode: 5115.06 
CPU-seconds in kernel mode: 142.79
real time: 1:32:42
CPU time: 94%CPU
```

* Optimized (using `std::vector`):

memory:
```
 Private  +   Shared  =  RAM used       Program
 62.5 GiB + 871.0 KiB =  62.5 GiB       witness_node
```

time of the blockchain replay & db reindexing:
```
CPU-seconds in user mode: 5059.77
CPU-seconds in kernel mode: 130.11
real time: 1:30:09
CPU time: 95%CPU 
```

* Optimised (using `raw array`):

memory:
```
 Private  +   Shared  =  RAM used       Program
 55.3 GiB + 573.0 KiB =  55.3 GiB       witness_node
```

time of the blockchain replay & db reindexing:
```
CPU-seconds in user mode: 5058.16
CPU-seconds in kernel mode: 133.52
real time: 1:31:03
CPU time: 95%CPU 
```

## Conclusion

Memory optimization doesn't seem to have effect on the blockchain replay performance.
On the other hand it seems to drastically reduce memory requirements for large amount of operations in the database (in this case almost 67GiB what is around 55%)

*This pull request contains code from the last test, i.e. optimization using `raw array`.*