### PR TITLE
Safer way to handle unlock command of cli_wallet #1171

### DIFF
--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -210,7 +210,7 @@ static int cli_completion(char *token, char ***array)
  */
 static int cli_check_secret(const char *source)
 {
-   if (nullptr != cli_regex_secret().expression() && boost::regex_match(source, cli_regex_secret()))
+   if (!cli_regex_secret().empty() && boost::regex_match(source, cli_regex_secret()))
       return 1;
    
    return 0;

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -210,7 +210,7 @@ static int cli_completion(char *token, char ***array)
  */
 static int cli_check_secret(const char *source)
 {
-   if (boost::regex_match(source, cli_regex_secret()))
+   if (nullptr != cli_regex_secret().expression() && boost::regex_match(source, cli_regex_secret()))
       return 1;
    
    return 0;


### PR DESCRIPTION
Check if exists regex expression, this PR is for https://github.com/bitshares/bitshares-core/issues/1171 issue