### PR TITLE
Silence wrong tag warning

### DIFF
--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -97,7 +97,7 @@ namespace fc {
   };
 
   struct unsigned_int;
-  struct variant_object;
+  class variant_object;
   template<> struct get_typename<unsigned_int>   { static const char* name()   { return "unsigned_int";   } };
   template<> struct get_typename<variant_object>   { static const char* name()   { return "fc::variant_object";   } };
 


### PR DESCRIPTION
Somehow `variant_object` was referenced as `struct` here while it's actually a class.

Should get rid of related warnings when compiling.