### PR TITLE
Fix error and warning

### DIFF
--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -97,7 +97,7 @@ namespace fc {
   };
 
   struct unsigned_int;
-  struct variant_object;
+  class variant_object;
   template<> struct get_typename<unsigned_int>   { static const char* name()   { return "unsigned_int";   } };
   template<> struct get_typename<variant_object>   { static const char* name()   { return "fc::variant_object";   } };
 

--- a/src/thread/context.hpp
+++ b/src/thread/context.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <fc/thread/thread.hpp>
-#include <boost/context/all.hpp>
 #include <fc/exception/exception.hpp>
+#include <boost/context/continuation_fcontext.hpp>
 #include <vector>
 
 #include <boost/version.hpp>


### PR DESCRIPTION
 - Fix build against current boost, which no longer provides a `boost/context/all.hpp` header
 - Fix warning caused by incorrect forward-declaration of `variant_object` as a `struct` when it is actually a `class`