### PR TITLE
Fix build against boost 1.68+

### DIFF
--- a/src/thread/context.hpp
+++ b/src/thread/context.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <fc/thread/thread.hpp>
-#include <boost/context/all.hpp>
 #include <fc/exception/exception.hpp>
 #include <vector>
 
@@ -8,6 +7,12 @@
 
 #define BOOST_COROUTINES_NO_DEPRECATION_WARNING // Boost 1.61
 #define BOOST_COROUTINE_NO_DEPRECATION_WARNING // Boost 1.62
+
+#if BOOST_VERSION >= 106800
+#include <boost/context/continuation_fcontext.hpp>
+#else
+#include <boost/context/all.hpp>
+#endif
 
 #if BOOST_VERSION >= 106100
   #include <boost/coroutine/stack_allocator.hpp>


### PR DESCRIPTION
In Boost 1.68, the `boost/context/all.hpp` header was removed.
Ref: https://github.com/boostorg/context/commit/2e37599461912cc1679f106a25456a493f7f0b27
If building against Boost 1.68+, use `boost/context/continuation_fcontext.hpp` instead.