### PR TITLE
boost stacktrace does not play well with mac

### DIFF
--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -5,7 +5,7 @@
 #include <boost/version.hpp>
 
 // only include stacktrace stuff if boost >= 1.65
-#if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65
+#if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65 && !defined(__APPLE__)
 #include <signal.h>
 #include <fc/log/logger.hpp>
 #include <boost/stacktrace.hpp>

--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -5,7 +5,7 @@
 #include <boost/version.hpp>
 
 // only include stacktrace stuff if boost >= 1.65 and not macOS
-#if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65 && !defined(__APPLE__)
+#if BOOST_VERSION / 100 >= 1065 && !defined(__APPLE__)
 #include <signal.h>
 #include <fc/log/logger.hpp>
 #include <boost/stacktrace.hpp>

--- a/src/stacktrace.cpp
+++ b/src/stacktrace.cpp
@@ -4,7 +4,7 @@
 #include <ostream>
 #include <boost/version.hpp>
 
-// only include stacktrace stuff if boost >= 1.65
+// only include stacktrace stuff if boost >= 1.65 and not macOS
 #if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65 && !defined(__APPLE__)
 #include <signal.h>
 #include <fc/log/logger.hpp>

--- a/tests/stacktrace_test.cpp
+++ b/tests/stacktrace_test.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(stacktrace_test)
    std::stringstream ss;
    fc::print_stacktrace(ss);
    std::string results = ss.str();
-#if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65
+#if BOOST_VERSION / 100 >= 1065 && !defined(__APPLE__)
    BOOST_CHECK(!results.empty());
    BOOST_CHECK(results.find("fc::print_stacktrace") != std::string::npos);
 #else
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(threaded_stacktrace_test)
                return ss.str();
             }
          ).wait();
-#if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65
+#if BOOST_VERSION / 100 >= 1065 && !defined(__APPLE__)
    BOOST_CHECK(!results.empty());
    BOOST_CHECK(results.find("fc::print_stacktrace") != std::string::npos);
 #else
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(threaded_stacktrace_test)
 #endif
 }
 
-#if BOOST_VERSION / 100000 >= 1 && ((BOOST_VERSION / 100) % 1000) >= 65
+#if BOOST_VERSION / 100 >= 1065 && !defined(__APPLE__)
 class _svdt_visitor
 {
 public:


### PR DESCRIPTION
Boost versions above 1.65 implement a stacktrace feature that is used within Bitshares for debugging. That code is not implemented for macOS, so this PR adds a precompiler condition to remove that section of code when compiling on macOS.