### PR TITLE
mac fc::io::readsome fix

### DIFF
--- a/src/io/fstream.cpp
+++ b/src/io/fstream.cpp
@@ -65,11 +65,21 @@ namespace fc {
      const boost::filesystem::path& bfp = file; 
       my->ifs.open( bfp, std::ios::binary );
    }
+
    size_t ifstream::readsome( char* buf, size_t len ) {
       auto s = size_t(my->ifs.readsome( buf, len ));
       if( s <= 0 ) {
-         read( buf, 1 );
-         s = 1;
+         try
+         {
+            read( buf, len );
+            s = len;
+         }
+         catch (const fc::eof_exception& eof)
+         {
+            s = my->ifs.gcount();
+            if (s == 0)
+               throw eof;
+         }
       }
       return s;
    }

--- a/src/io/fstream.cpp
+++ b/src/io/fstream.cpp
@@ -68,17 +68,13 @@ namespace fc {
 
    size_t ifstream::readsome( char* buf, size_t len ) {
       auto s = size_t(my->ifs.readsome( buf, len ));
-      if( s <= 0 ) {
-         try
+      if( s <= 0 ) 
+      {
+         read( buf, 1 );
+         s = 1;
+         if (len > 1)
          {
-            read( buf, len );
-            s = len;
-         }
-         catch (const fc::eof_exception& eof)
-         {
-            s = my->ifs.gcount();
-            if (s == 0)
-               throw eof;
+            s += size_t(my->ifs.readsome( &buf[1], len - 1));
          }
       }
       return s;

--- a/tests/io/stream_tests.cpp
+++ b/tests/io/stream_tests.cpp
@@ -112,11 +112,11 @@ BOOST_AUTO_TEST_CASE(fstream_test)
    BOOST_CHECK_THROW( in2.readsome( buf, 3, 0 ), fc::eof_exception );
 
    {
-      out.flush();
+      out.close();
       std::fstream test( outf.path().to_native_ansi_path(), std::fstream::in );
-      BOOST_CHECK_EQUAL( 11u, test.readsome( (&(*buf)), 11 ) );
+      test.read( (&(*buf)), 11 );
       BOOST_CHECK_EQUAL( "Hello world", std::string( (&(*buf)), 11 ) );
-      BOOST_CHECK_EQUAL( 0u, test.readsome( (&(*buf)), 11 ) );
+      BOOST_CHECK(!test.read( (&(*buf)), 11 ));
       test.close();
    }
 
@@ -166,11 +166,11 @@ BOOST_AUTO_TEST_CASE(buffered_fstream_test)
    BOOST_CHECK_THROW( bin2.readsome( buf, 3, 0 ), fc::eof_exception );
 
    {
-      bout.flush();
+      bout.close();
       std::fstream test( outf.path().to_native_ansi_path(), std::fstream::in );
-      BOOST_CHECK_EQUAL( 11u, test.readsome( (&(*buf)), 11 ) );
+      test.read( (&(*buf)), 11 );
       BOOST_CHECK_EQUAL( "Hello world", std::string( (&(*buf)), 11 ) );
-      BOOST_CHECK_EQUAL( 0u, test.readsome( (&(*buf)), 11 ) );
+      BOOST_CHECK(!test.read( (&(*buf)), 11 ));
       test.close();
    }
 }


### PR DESCRIPTION
std::istream::readsome only reads what is in the buffer. If there is nothing in the buffer, nothing is read.

For at least file streams, it seems that the implementation on Linux and Windows will read the file into the buffer at some point, and readsome() will return that buffer. On macOS, the buffer will be empty, and readsome() will return nothing.

The fc::istream::readsome() seems to have implemented a small work-around, that (to me) looks half-baked. It seems to force reading 1 byte into the stream. This goes against the specification for the standard library and produces unwanted results.

IMO: We need to either 1) make fc::ifstream::readsome() work more like std::readsome or 2) modify fc::ifstream::readsome() to read more than 1 byte. Here are the pros and cons of each:

Option 1: Making it work like std::ifstream::readsome() will make the method consistent with the standard library. But if we want consistency, why not use the standard library? In addition, this change may break existing code.

Option 2: Have fc::ifstream::readsome() read more than 1 byte. This is not consistent with how the standard library works, but is consistent with existing code. I also believe this is what was intended by the original developer, although it seems it was not tested on all platforms.

This PR is an implementation of option 2.

Note: This fix was tested on a mac virtual machine. It needs to be tested in a non-virtual environment, which I will do soon.