### PR TITLE
fix compiler error of api_visitor::to_generic on MSVC

### DIFF
--- a/include/fc/rpc/binary_api_connection.hpp
+++ b/include/fc/rpc/binary_api_connection.hpp
@@ -13,6 +13,7 @@
 
 namespace fc {
    class binary_api_connection;
+   using std::vector;
 
    namespace detail {
       template<typename Signature>


### PR DESCRIPTION
When i use VS 2017 compiler bitshares-core, take some error in `api_visitor` class( e.g `to_generic` and `call_generic`  member function).
such as:
`
>d:\bitshares\bitshares-core\libraries\fc\tests\api.cpp(62): note: 参见对正在编译的函数 模板 实例化“void fc::api_connection::api_visitor::operator ()<fc::api<calculator,fc::identity_member>,>(const char *,std::function<fc::api<calculator,fc::identity_member> (void)> &) const”的引用
2>d:\bitshares\bitshares-core\libraries\fc\include\fc\rpc\api_connection.hpp(223): note: 参见对正在编译的函数 模板 实例化“void fc::vtable<Interface,Transform>::visit<fc::api_connection::api_visitor>(Visitor &&)”的引用
2>        with
2>        [
2>            Interface=login_api,
2>            Transform=fc::identity_member,
2>            Visitor=fc::api_connection::api_visitor
2>        ]
2>d:\bitshares\bitshares-core\libraries\fc\include\fc\rpc\api_connection.hpp(223): note: 参见对正在编译的函数 模板 实例化“void fc::vtable<Interface,Transform>::visit<fc::api_connection::api_visitor>(Visitor &&)”的引用
2>        with
2>        [
2>            Interface=login_api,
2>            Transform=fc::identity_member,
2>            Visitor=fc::api_connection::api_visitor
2>        ]
2>d:\bitshares\bitshares-core\libraries\fc\tests\api.cpp(113): note: 参见对正在编译的函数 模板 实例化“fc::api<login_api,fc::identity_member> fc::api_connection::get_remote_api<login_api>(fc::api_id_type)”的引用
`
(sorry, my os language is chinese, so you maybe don't understand this error ?)

I think it because the different of gcc between  msvc, so i fix it through class template . test ok on linux and vs2017.