### PR TITLE
Remove boost signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 SET (ORIGINAL_LIB_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
 SET(BOOST_COMPONENTS)
-LIST(APPEND BOOST_COMPONENTS thread date_time filesystem system program_options signals serialization chrono unit_test_framework context locale iostreams regex)
+LIST(APPEND BOOST_COMPONENTS thread date_time filesystem system program_options serialization chrono unit_test_framework context locale iostreams regex)
 SET( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 
 IF( ECC_IMPL STREQUAL openssl )


### PR DESCRIPTION
Boost 1.69 no longer ships with signals, and we no longer use it. This simply removes the requirement from the CMakeLists.txt file.

`Fixes` bitshares/bitshares-core/issues/1512