### PR TITLE
Fix some macOS warnings

### DIFF
--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -631,7 +631,7 @@ namespace fc
               to_stream(os, v.get_object(), format, max_depth - 1 );
               return;
          default:
-            FC_THROW_EXCEPTION( fc::invalid_arg_exception, "Unsupported variant type: " + std::to_string(v.get_type()) );
+            FC_THROW_EXCEPTION( fc::invalid_arg_exception, "Unsupported variant type: ${type}", ( "type", v.get_type() ) );
       }
    }
 

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -631,7 +631,7 @@ namespace fc
               to_stream(os, v.get_object(), format, max_depth - 1 );
               return;
          default:
-            FC_THROW_EXCEPTION( fc::invalid_arg_exception, "Unsupported variant type: " + v.get_type() );
+            FC_THROW_EXCEPTION( fc::invalid_arg_exception, "Unsupported variant type: " + std::to_string(v.get_type()) );
       }
    }
 

--- a/tests/thread/parallel_tests.cpp
+++ b/tests/thread/parallel_tests.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE( do_something_parallel )
    results.reserve( 20 );
    boost::thread_specific_ptr<int> tls;
    for( size_t i = 0; i < results.capacity(); i++ )
-      results.push_back( fc::do_parallel( [i,&tls] () {
+      results.push_back( fc::do_parallel( [&tls] () {
          if( !tls.get() ) { tls.reset( new int(0) ); }
          result res = { boost::this_thread::get_id(), (*tls.get())++ };
          return res;


### PR DESCRIPTION
When compiling on macOS, a warning is displayed about adding an int to a string literal probably is not what was intended. This fixes the problem, and the warning is no longer displayed.

Also, one test had an unnecessary capture for a lambda.