### PR TITLE
Remove unnecessary asserts

### DIFF
--- a/include/fc/container/flat.hpp
+++ b/include/fc/container/flat.hpp
@@ -25,7 +25,6 @@ namespace fc {
          --_max_depth;
          unsigned_int size; unpack( s, size, _max_depth );
          value.clear();
-         FC_ASSERT( size.value*sizeof(T) < MAX_ARRAY_ALLOC_SIZE );
          value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
          for( uint32_t i = 0; i < size.value; ++i )
          {
@@ -53,7 +52,6 @@ namespace fc {
          --_max_depth;
          unsigned_int size; unpack( s, size, _max_depth );
          value.clear();
-         FC_ASSERT( size.value*(sizeof(K)+sizeof(V)) < MAX_ARRAY_ALLOC_SIZE );
          value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
          for( uint32_t i = 0; i < size.value; ++i )
          {

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -261,7 +261,6 @@ namespace fc {
     template<typename Stream> inline void unpack( Stream& s, std::vector<char>& value, uint32_t _max_depth ) {
        FC_ASSERT( _max_depth > 0 );
        unsigned_int size; fc::raw::unpack( s, size, _max_depth - 1 );
-       FC_ASSERT( size.value < MAX_ARRAY_ALLOC_SIZE );
        value.resize(size.value);
        if( value.size() )
           s.read( value.data(), value.size() );
@@ -428,7 +427,6 @@ namespace fc {
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
        value.clear();
-       FC_ASSERT( size.value*sizeof(T) < MAX_ARRAY_ALLOC_SIZE );
        value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
        for( uint32_t i = 0; i < size.value; ++i )
        {
@@ -474,7 +472,6 @@ namespace fc {
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
        value.clear();
-       FC_ASSERT( size.value*(sizeof(K)+sizeof(V)) < MAX_ARRAY_ALLOC_SIZE );
        value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
        for( uint32_t i = 0; i < size.value; ++i )
        {
@@ -502,7 +499,6 @@ namespace fc {
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
        value.clear();
-       FC_ASSERT( size.value*(sizeof(K)+sizeof(V)) < MAX_ARRAY_ALLOC_SIZE );
        for( uint32_t i = 0; i < size.value; ++i )
        {
           std::pair<K,V> tmp;
@@ -529,7 +525,6 @@ namespace fc {
        FC_ASSERT( _max_depth > 0 );
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
-       FC_ASSERT( size.value*sizeof(T) < MAX_ARRAY_ALLOC_SIZE );
        value.resize( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
        for( uint64_t i = 0; i < size; i++ )
        {
@@ -557,7 +552,6 @@ namespace fc {
        FC_ASSERT( _max_depth > 0 );
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
-       FC_ASSERT( size.value*sizeof(T) < MAX_ARRAY_ALLOC_SIZE );
        value.resize( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
        for( uint64_t i = 0; i < size; i++ )
        {

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -261,6 +261,7 @@ namespace fc {
     template<typename Stream> inline void unpack( Stream& s, std::vector<char>& value, uint32_t _max_depth ) {
        FC_ASSERT( _max_depth > 0 );
        unsigned_int size; fc::raw::unpack( s, size, _max_depth - 1 );
+       FC_ASSERT( size.value < MAX_ARRAY_ALLOC_SIZE );
        value.resize(size.value);
        if( value.size() )
           s.read( value.data(), value.size() );

--- a/include/fc/io/raw_fwd.hpp
+++ b/include/fc/io/raw_fwd.hpp
@@ -1,4 +1,4 @@
-#pragma once
+#pragma once 
 #include <fc/config.hpp>
 #include <fc/container/flat_fwd.hpp>
 #include <fc/container/deque_fwd.hpp>
@@ -11,6 +11,8 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <set>
+
+#define MAX_ARRAY_ALLOC_SIZE (1024*1024*10)
 
 namespace fc {
    class time_point;

--- a/include/fc/io/raw_fwd.hpp
+++ b/include/fc/io/raw_fwd.hpp
@@ -12,8 +12,6 @@
 #include <unordered_map>
 #include <set>
 
-#define MAX_ARRAY_ALLOC_SIZE (1024*1024*10)
-
 namespace fc {
    class time_point;
    class time_point_sec;

--- a/include/fc/io/raw_fwd.hpp
+++ b/include/fc/io/raw_fwd.hpp
@@ -1,4 +1,4 @@
-#pragma once 
+#pragma once
 #include <fc/config.hpp>
 #include <fc/container/flat_fwd.hpp>
 #include <fc/container/deque_fwd.hpp>

--- a/include/fc/io/raw_variant.hpp
+++ b/include/fc/io/raw_variant.hpp
@@ -143,7 +143,6 @@ namespace fc { namespace raw {
        --_max_depth;
        unsigned_int vs;
        unpack( s, vs, _max_depth );
-       FC_ASSERT( vs.value*sizeof(variant_object::entry) < MAX_ARRAY_ALLOC_SIZE );
        mutable_variant_object mvo;
        mvo.reserve( std::min( vs.value, FC_MAX_PREALLOC_SIZE ) );
        for( uint32_t i = 0; i < vs.value; ++i )


### PR DESCRIPTION
This is part of issue https://github.com/bitshares/bitshares-core/issues/995

Originally, it was proposed to be a bit more granular in calculating maximum allocations sizes for array-like containers. Such a change must be careful to not break consensus.

A subsequent change (see #100) protects nodes from large transactions entering from the network, thereby minimizing or eliminating the need for checks in those unpacking routines.

This pull removes those checks.

Related: #55 