### PR TITLE
fix std::min parameter conversion

### DIFF
--- a/include/fc/container/flat.hpp
+++ b/include/fc/container/flat.hpp
@@ -25,7 +25,7 @@ namespace fc {
          --_max_depth;
          unsigned_int size; unpack( s, size, _max_depth );
          value.clear();
-         value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
+         value.reserve( std::min( size.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
          for( uint32_t i = 0; i < size.value; ++i )
          {
              T tmp;
@@ -52,7 +52,7 @@ namespace fc {
          --_max_depth;
          unsigned_int size; unpack( s, size, _max_depth );
          value.clear();
-         value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
+         value.reserve( std::min( size.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
          for( uint32_t i = 0; i < size.value; ++i )
          {
              std::pair<K,V> tmp;
@@ -85,11 +85,11 @@ namespace fc {
           unsigned_int size;
           unpack( s, size, _max_depth );
           if( !std::is_fundamental<T>::value ) {
-             value.resize( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
+             value.resize( std::min( size.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
              for( uint64_t i = 0; i < size; i++ )
              {
                 if( i >= value.size() )
-                   value.resize( std::min( 2*value.size(), size.value ) );
+                   value.resize( std::min( static_cast<uint64_t>(2*value.size()), size.value ) );
                 unpack( s, value[i], _max_depth );
              }
           } else {

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -428,7 +428,7 @@ namespace fc {
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
        value.clear();
-       value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
+       value.reserve( std::min( size.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
        for( uint32_t i = 0; i < size.value; ++i )
        {
           T tmp;
@@ -473,7 +473,7 @@ namespace fc {
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
        value.clear();
-       value.reserve( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
+       value.reserve( std::min( size.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
        for( uint32_t i = 0; i < size.value; ++i )
        {
           std::pair<K,V> tmp;
@@ -526,11 +526,11 @@ namespace fc {
        FC_ASSERT( _max_depth > 0 );
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
-       value.resize( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
+       value.resize( std::min( size.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
        for( uint64_t i = 0; i < size; i++ )
        {
           if( i >= value.size() )
-             value.resize( std::min( 2*value.size(), size.value ) );
+             value.resize( std::min( static_cast<uint64_t>(2*value.size()), size.value ) );
           unpack( s, value[i], _max_depth );
        }
     }
@@ -553,11 +553,11 @@ namespace fc {
        FC_ASSERT( _max_depth > 0 );
        --_max_depth;
        unsigned_int size; fc::raw::unpack( s, size, _max_depth );
-       value.resize( std::min( size.value, FC_MAX_PREALLOC_SIZE ) );
+       value.resize( std::min( size.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
        for( uint64_t i = 0; i < size; i++ )
        {
           if( i >= value.size() )
-             value.resize( std::min( 2*value.size(), size.value ) );
+             value.resize( std::min( static_cast<uint64_t>(2*value.size()), size.value ) );
           unpack( s, value[i], _max_depth );
        }
     }

--- a/include/fc/io/raw_variant.hpp
+++ b/include/fc/io/raw_variant.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <fc/exception/exception.hpp>
 #include <fc/io/raw_fwd.hpp>
 #include <fc/variant_object.hpp>
@@ -144,7 +145,7 @@ namespace fc { namespace raw {
        unsigned_int vs;
        unpack( s, vs, _max_depth );
        mutable_variant_object mvo;
-       mvo.reserve( std::min( vs.value, FC_MAX_PREALLOC_SIZE ) );
+       mvo.reserve( std::min( vs.value, static_cast<uint64_t>(FC_MAX_PREALLOC_SIZE) ) );
        for( uint32_t i = 0; i < vs.value; ++i )
        {
           fc::string key;


### PR DESCRIPTION
Fixes /bitshares/bitshares-core/issues/1560

std::min does not do implicit conversions. macOS has a different sized size_t that forces us to cast the std::min parameters.