### PR TITLE
Add missing operator overloads for fc::unsigned_int

### DIFF
--- a/include/fc/io/varint.hpp
+++ b/include/fc/io/varint.hpp
@@ -28,6 +28,14 @@ struct unsigned_int {
     friend bool operator<( const uint64_t& i, const unsigned_int& v )      { return i       < v.value; }
     friend bool operator<( const unsigned_int& i, const unsigned_int& v )  { return i.value < v.value; }
 
+    friend bool operator<=( const unsigned_int& i, const uint64_t& v )     { return i.value <= v; }
+    friend bool operator<=( const uint64_t& i, const unsigned_int& v )     { return i       <= v.value; }
+    friend bool operator<=( const unsigned_int& i, const unsigned_int& v ) { return i.value <= v.value; }
+
+    friend bool operator>( const unsigned_int& i, const uint64_t& v )      { return i.value > v; }
+    friend bool operator>( const uint64_t& i, const unsigned_int& v )      { return i       > v.value; }
+    friend bool operator>( const unsigned_int& i, const unsigned_int& v )  { return i.value > v.value; }
+
     friend bool operator>=( const unsigned_int& i, const uint64_t& v )     { return i.value >= v; }
     friend bool operator>=( const uint64_t& i, const unsigned_int& v )     { return i       >= v.value; }
     friend bool operator>=( const unsigned_int& i, const unsigned_int& v ) { return i.value >= v.value; }


### PR DESCRIPTION
Turns out that bitshares/bitshares-core#1506 is easier if you can
do greater-than comparisons on fc::unsigned_int. Go ahead and add
the complement of missing operators.