### PR TITLE
Enable websocket permessage-deflate (follow-up of #106)

### DIFF
--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -6,6 +6,8 @@
 #include <websocketpp/client.hpp>
 #include <websocketpp/logger/stub.hpp>
 
+#include <websocketpp/extensions/permessage_deflate/enabled.hpp>
+
 #include <fc/optional.hpp>
 #include <fc/variant.hpp>
 #include <fc/thread/thread.hpp>
@@ -61,6 +63,11 @@ namespace fc { namespace http {
               transport_type;
 
           static const long timeout_open_handshake = 0;
+
+       // permessage_compress extension
+       struct permessage_deflate_config {};
+       typedef websocketpp::extensions::permessage_deflate::enabled <permessage_deflate_config> permessage_deflate_type;
+
       };
       struct asio_tls_with_stub_log : public websocketpp::config::asio_tls {
 


### PR DESCRIPTION
This PR is a follow-up of #106. Bumped websocketpp version.