### PR TITLE
Allow zlib to be optional

### DIFF
--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -6,7 +6,11 @@
 #include <websocketpp/client.hpp>
 #include <websocketpp/logger/stub.hpp>
 
+#ifdef HAS_ZLIB
 #include <websocketpp/extensions/permessage_deflate/enabled.hpp>
+#else
+#include <websocketpp/extensions/permessage_deflate/disabled.hpp>
+#endif
 
 #include <fc/optional.hpp>
 #include <fc/variant.hpp>
@@ -66,7 +70,11 @@ namespace fc { namespace http {
 
        // permessage_compress extension
        struct permessage_deflate_config {};
+#ifdef HAS_ZLIB
        typedef websocketpp::extensions::permessage_deflate::enabled <permessage_deflate_config> permessage_deflate_type;
+#else
+       typedef websocketpp::extensions::permessage_deflate::disabled <permessage_deflate_config> permessage_deflate_type;
+#endif
 
       };
       struct asio_tls_with_stub_log : public websocketpp::config::asio_tls {


### PR DESCRIPTION
permessage_deflate was added assuming zlib will always be available. This change allows compilation without zlib.

Part of https://github.com/bitshares/bitshares-core/issues/1593