### PR TITLE
Equality check does not work on Windows

### DIFF
--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -70,7 +70,10 @@ BOOST_AUTO_TEST_CASE( types_edge_cases_test )
 
    sv::tag_type current_value = variant_with_tagtype.get<sv::tag_type>();
    BOOST_CHECK_EQUAL( current_value, init_value );
+#ifndef _WIN32
+   // this does not work in Windows. See Issue #1593
    BOOST_CHECK( variant_with_tagtype == init_value );
+#endif
 
    for (sv::tag_type i = variant_with_tagtype.count(); i-->0;)
    {

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE( types_edge_cases_test )
 
    sv::tag_type current_value = variant_with_tagtype.get<sv::tag_type>();
    BOOST_CHECK_EQUAL( current_value, init_value );
-   BOOST_CHECK(variant_with_tagtype.get<sv::tag_type>() == init_value);
+   BOOST_CHECK( variant_with_tagtype.get<sv::tag_type>() == init_value );
 
    for (sv::tag_type i = variant_with_tagtype.count(); i-->0;)
    {

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -70,10 +70,7 @@ BOOST_AUTO_TEST_CASE( types_edge_cases_test )
 
    sv::tag_type current_value = variant_with_tagtype.get<sv::tag_type>();
    BOOST_CHECK_EQUAL( current_value, init_value );
-#ifndef _WIN32
-   // this does not work in Windows. See Issue #1593
-   BOOST_CHECK( variant_with_tagtype == init_value );
-#endif
+   BOOST_CHECK(variant_with_tagtype.get<sv::tag_type>() == init_value);
 
    for (sv::tag_type i = variant_with_tagtype.count(); i-->0;)
    {


### PR DESCRIPTION
Part of /bitshares/bitshares-core/issues/1593

Compiling on Windows causes an error. It seems the compiler cannot determine which equality operator to use given the arguments. As a "fix", the preprocessor removes this test line from Windows builds.

"E:\bitshares-core-hardfork\install.vcxproj" (default target) (1) ->
"E:\bitshares-core-hardfork\ALL_BUILD.vcxproj" (default target) (3) ->
"E:\bitshares-core-hardfork\libraries\fc\tests\all_tests.vcxproj" (default target) (4) ->
(ClCompile target) ->
  E:\bitshares-core-hardfork\libraries\fc\tests\variant_test.cpp(73): error C2666: 'fc::test::operator ==': 6 overloads have similar conversions [E:\bitshares-core-hardfork\libraries\fc\tests\all_tests.vcxproj]

I do not like this fix, as it is not testing a feature that could be used elsewhere (which I assume would also fail to compile). It looks as if the way equality is done here is broken (on Windows), and needs to be fixed. Input from others would be appreciated.