### PR TITLE
Make static_variant::tag_type public

### DIFF
--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -253,6 +253,9 @@ static const fc::array<typename Visitor::result_type(*)(Visitor&,Data),L>
 
 template<typename... Types>
 class static_variant {
+public:
+    using tag_type = int64_t;
+
 protected:
     static_assert(impl::type_info<Types...>::no_reference_types, "Reference types are not permitted in static_variant.");
     static_assert(impl::type_info<Types...>::no_duplicates, "static_variant type arguments contain duplicate types.");
@@ -260,7 +263,6 @@ protected:
     template<typename X>
     using type_in_typelist = typename std::enable_if<impl::position<X, Types...>::pos != -1, X>::type; // type is in typelist of static_variant.
 
-    using tag_type = int64_t;
     tag_type _tag;
     impl::dynamic_storage storage;
 


### PR DESCRIPTION
It's used in the public interface, so it needs to be a publicly
defined type