### PR TITLE
Help compiler infer correct templated method

### DIFF
--- a/include/fc/rpc/api_connection.hpp
+++ b/include/fc/rpc/api_connection.hpp
@@ -146,7 +146,7 @@ namespace fc {
             return f();
          }
 
-         template<typename R, typename Signature, typename ... Args>
+         template<typename R, typename Signature, typename ... Args, typename std::enable_if<std::is_function<Signature>::value,Signature>::type* = nullptr>
          R call_generic( const std::function<R(std::function<Signature>,Args...)>& f, variants::const_iterator a0, variants::const_iterator e, uint32_t max_depth )
          {
             FC_ASSERT( a0 != e, "too few arguments passed to method" );
@@ -154,7 +154,7 @@ namespace fc {
             detail::callback_functor<Signature> arg0( get_connection(), a0->as<uint64_t>(1) );
             return call_generic<R,Args...>( this->bind_first_arg<R,std::function<Signature>,Args...>( f, std::function<Signature>(arg0) ), a0+1, e, max_depth - 1 );
          }
-         template<typename R, typename Signature, typename ... Args>
+         template<typename R, typename Signature, typename ... Args, typename std::enable_if<std::is_function<Signature>::value,Signature>::type* = nullptr>
          R call_generic( const std::function<R(const std::function<Signature>&,Args...)>& f, variants::const_iterator a0, variants::const_iterator e, uint32_t max_depth )
          {
             FC_ASSERT( a0 != e, "too few arguments passed to method" );

--- a/include/fc/rpc/api_connection.hpp
+++ b/include/fc/rpc/api_connection.hpp
@@ -146,21 +146,27 @@ namespace fc {
             return f();
          }
 
-         template<typename R, typename Signature, typename ... Args, typename std::enable_if<std::is_function<Signature>::value,Signature>::type* = nullptr>
-         R call_generic( const std::function<R(std::function<Signature>,Args...)>& f, variants::const_iterator a0, variants::const_iterator e, uint32_t max_depth )
+         template<typename R, typename Signature, typename ... Args, 
+               typename std::enable_if<std::is_function<Signature>::value,Signature>::type* = nullptr>
+         R call_generic( const std::function<R(std::function<Signature>,Args...)>& f, 
+               variants::const_iterator a0, variants::const_iterator e, uint32_t max_depth )
          {
             FC_ASSERT( a0 != e, "too few arguments passed to method" );
             FC_ASSERT( max_depth > 0, "Recursion depth exceeded!" );
             detail::callback_functor<Signature> arg0( get_connection(), a0->as<uint64_t>(1) );
-            return call_generic<R,Args...>( this->bind_first_arg<R,std::function<Signature>,Args...>( f, std::function<Signature>(arg0) ), a0+1, e, max_depth - 1 );
+            return call_generic<R,Args...>( this->bind_first_arg<R,std::function<Signature>,Args...>( f, 
+                  std::function<Signature>(arg0) ), a0+1, e, max_depth - 1 );
          }
-         template<typename R, typename Signature, typename ... Args, typename std::enable_if<std::is_function<Signature>::value,Signature>::type* = nullptr>
-         R call_generic( const std::function<R(const std::function<Signature>&,Args...)>& f, variants::const_iterator a0, variants::const_iterator e, uint32_t max_depth )
+         template<typename R, typename Signature, typename ... Args, 
+               typename std::enable_if<std::is_function<Signature>::value,Signature>::type* = nullptr>
+         R call_generic( const std::function<R(const std::function<Signature>&,Args...)>& f, 
+               variants::const_iterator a0, variants::const_iterator e, uint32_t max_depth )
          {
             FC_ASSERT( a0 != e, "too few arguments passed to method" );
             FC_ASSERT( max_depth > 0, "Recursion depth exceeded!" );
             detail::callback_functor<Signature> arg0( get_connection(), a0->as<uint64_t>(1) );
-            return call_generic<R,Args...>( this->bind_first_arg<R,const std::function<Signature>&,Args...>( f, arg0 ), a0+1, e, max_depth - 1 );
+            return call_generic<R,Args...>( this->bind_first_arg<R,const std::function<Signature>&,Args...>( f, 
+                  arg0 ), a0+1, e, max_depth - 1 );
          }
 
          template<typename R, typename Arg0, typename ... Args>

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -226,7 +226,7 @@ template<int L,typename Visitor,typename Data,typename T, typename ... Types>
 static const fc::array<typename Visitor::result_type(*)(Visitor&,Data),L>
       init_wrappers( Visitor& v, Data d, typename Visitor::result_type(**funcs)(Visitor&,Data) = 0 )
 {
-   fc::array<typename Visitor::result_type(*)(Visitor&,Data),L> result;
+   fc::array<typename Visitor::result_type(*)(Visitor&,Data),L> result{};
    if( !funcs ) funcs = result.begin();
    *funcs++ = [] ( Visitor& v, Data d ) { return v( *reinterpret_cast<T*>( d ) ); };
    init_wrappers<L,Visitor,Data,Types...>( v, d, funcs );
@@ -244,7 +244,7 @@ template<int L,typename Visitor,typename Data,typename T, typename ... Types>
 static const fc::array<typename Visitor::result_type(*)(Visitor&,Data),L>
       init_const_wrappers( Visitor& v, Data d, typename Visitor::result_type(**funcs)(Visitor&,Data) = 0 )
 {
-   fc::array<typename Visitor::result_type(*)(Visitor&,Data),L> result;
+   fc::array<typename Visitor::result_type(*)(Visitor&,Data),L> result{};
    if( !funcs ) funcs = result.begin();
    *funcs++ = [] ( Visitor& v, Data d ) { return v( *reinterpret_cast<const T*>( d ) ); };
    init_const_wrappers<L,Visitor,Data,Types...>( v, d, funcs );


### PR DESCRIPTION
"Fixes" (updated by @abitmore to not automatically close that issue) https://github.com/bitshares/bitshares-core/issues/1646

At times compilers need assistance selecting the correct templated method. In this case MSVC versions > 14.0 (Visual Studio 2015 Update 1) were selecting the incorrect template due to template parameters being too ambiguous. 

This fix provides additional template parameters so that the compiler can select the correct templated method. It has been tested with MSVC 14.10 (Visual Studio 2017).

**Note** spacing was also fixed, as these lines were long. Be assured that the only addition here is within the template<> area of two call_generic method signatures.

**Note** compiling in Debug mode caused an error when embed_genesis.exe ran. This was due to default initialization within static_variant.hpp. Changed return value to be value initialized.