### PR TITLE
valgrind inspired fixes

### DIFF
--- a/include/fc/shared_ptr.hpp
+++ b/include/fc/shared_ptr.hpp
@@ -46,7 +46,7 @@ namespace fc {
       shared_ptr( shared_ptr&& p )
       :_ptr(p._ptr){ p._ptr = nullptr; }
 
-      ~shared_ptr() { if( nullptr != _ptr ) { _ptr->release(); } }
+      ~shared_ptr() { if( nullptr != _ptr ) { _ptr->release(); _ptr = nullptr; } }
 
       shared_ptr& reset( T* v = nullptr, bool inc = false )  {
         if( v == _ptr ) return *this;

--- a/src/crypto/openssl.cpp
+++ b/src/crypto/openssl.cpp
@@ -39,7 +39,10 @@ namespace  fc
 
        ~openssl_scope()
        {
+          FIPS_mode_set(0);
+          CONF_modules_unload(1);
           EVP_cleanup();
+          CRYPTO_cleanup_all_ex_data();
           ERR_free_strings();
        }
     };

--- a/src/thread/thread.cpp
+++ b/src/thread/thread.cpp
@@ -77,6 +77,7 @@ namespace fc {
           try {
             set_thread_name(name.c_str()); // set thread's name for the debugger to display
             this->my = new thread_d( *this, notifier );
+            cleanup();
             current_thread() = this;
             p->set_value();
             exec();
@@ -126,8 +127,10 @@ namespace fc {
    }
 
    void thread::cleanup() {
-     delete current_thread();
-     current_thread() = nullptr;
+     if ( current_thread() ) {
+        delete current_thread();
+        current_thread() = nullptr;
+     }
    }
 
    const string& thread::name()const

--- a/src/thread/thread_d.hpp
+++ b/src/thread/thread_d.hpp
@@ -52,6 +52,7 @@ namespace fc {
             ~thread_d()
             {
               delete current;
+              current = nullptr;
               fc::context* temp;
               for (fc::context* ready_context : ready_heap)
                 delete ready_context;


### PR DESCRIPTION
Hey Monkeys!

I had some troubles and run the witness_node with valgrind (the memcheck tool). As a result, I provide here some minor fixes.

Note that some of them may seem to be void from the point of a c++ knowledgeable programmer, yet I suppose to include them because they simplify the output from valgrind.

Ape out!