### PR TITLE
 Use shared_ptr to WS connection in API connection

### DIFF
--- a/include/fc/interprocess/signals.hpp
+++ b/include/fc/interprocess/signals.hpp
@@ -1,8 +1,11 @@
 #pragma once
 #include <functional>
+#include <boost/asio/signal_set.hpp>
 
 namespace fc 
 {
-  /// handler will be called from ASIO thread
-  void set_signal_handler( std::function<void(int)> handler, int signal_num ); 
+   /// Set a handler to process an IPC (inter process communication) signal.
+   /// Handler will be called from ASIO thread.
+   /// @return shared pointer to the signal_set that holds the handler
+   std::shared_ptr<boost::asio::signal_set> set_signal_handler( std::function<void(int)> handler, int signal_num );
 }

--- a/include/fc/rpc/cli.hpp
+++ b/include/fc/rpc/cli.hpp
@@ -25,6 +25,7 @@ namespace fc { namespace rpc {
 
          void start();
          void stop();
+         void cancel();
          void wait();
          void format_result( const string& method, std::function<string(variant,const variants&)> formatter);
 
@@ -40,5 +41,6 @@ namespace fc { namespace rpc {
          std::string _prompt = ">>>";
          std::map<string,std::function<string(variant,const variants&)> > _result_formatters;
          fc::future<void> _run_complete;
+         fc::thread* _getline_thread = nullptr; ///< Wait for user input in this thread
    };
 } } 

--- a/include/fc/rpc/websocket_api.hpp
+++ b/include/fc/rpc/websocket_api.hpp
@@ -10,7 +10,8 @@ namespace fc { namespace rpc {
    class websocket_api_connection : public api_connection
    {
       public:
-         websocket_api_connection( fc::http::websocket_connection& c, uint32_t max_conversion_depth );
+         websocket_api_connection( const std::shared_ptr<fc::http::websocket_connection> &c,
+                                   uint32_t max_conversion_depth );
          ~websocket_api_connection();
 
          virtual variant send_call(
@@ -29,8 +30,8 @@ namespace fc { namespace rpc {
             const std::string& message,
             bool send_message = true );
 
-         fc::http::websocket_connection&  _connection;
-         fc::rpc::state                   _rpc_state;
+         std::shared_ptr<fc::http::websocket_connection>  _connection;
+         fc::rpc::state                                   _rpc_state;
    };
 
 } } // namespace fc::rpc

--- a/include/fc/thread/thread.hpp
+++ b/include/fc/thread/thread.hpp
@@ -131,6 +131,11 @@ namespace fc {
        *  @todo make quit non-blocking of the calling thread by eliminating the call to <code>boost::thread::join</code>
        */
       void quit();
+
+      /**
+       * Send signal to underlying native thread. Only for Linux and macOS
+       */
+      void signal(int);
      
       /**
        *  @return true unless quit() has been called.

--- a/src/interprocess/signals.cpp
+++ b/src/interprocess/signals.cpp
@@ -3,15 +3,16 @@
 
 namespace fc
 {
-  void set_signal_handler( std::function<void(int)> handler, int signal_num )
-  {
-      std::shared_ptr<boost::asio::signal_set> sig_set(new boost::asio::signal_set(fc::asio::default_io_service(), signal_num));
-      sig_set->async_wait( 
-            [sig_set,handler]( const boost::system::error_code& err, int num ) 
-            {
-                handler( num );     
-                sig_set->cancel();
-             //   set_signal_handler( handler, signal_num );
-            } );
-  }
+   std::shared_ptr<boost::asio::signal_set> set_signal_handler( std::function<void(int)> handler, int signal_num )
+   {
+      std::shared_ptr<boost::asio::signal_set> sig_set( new boost::asio::signal_set( fc::asio::default_io_service(),
+                                                                                     signal_num) );
+      sig_set->async_wait( [sig_set,handler]( const boost::system::error_code& err, int num )
+      {
+         if( err != boost::asio::error::operation_aborted )
+            handler( num );
+         sig_set->cancel();
+      } );
+      return sig_set;
+   }
 }

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -56,6 +56,11 @@ void cli::send_notice( uint64_t callback_id, variants args /* = variants() */ )
 void cli::start()
 {
    cli_commands() = get_method_names(0);
+
+#ifdef HAVE_EDITLINE
+el_hist_size = 256;
+#endif
+
    _run_complete = fc::async( [&](){ run(); } );
 }
 

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -140,8 +140,6 @@ void cli::run()
       }
       catch ( const fc::exception& e )
       {
-         std::cout << e.to_detail_string() << "\n";
-
          if (e.code() == fc::canceled_exception_code)
          {
             if( _getline_thread )
@@ -151,6 +149,7 @@ void cli::run()
             }
             break;
          }
+         std::cout << e.to_detail_string() << "\n";
       }
    }
 }

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -257,15 +257,23 @@ static int cli_check_secret(const char *source)
    return 0;
 }
 
+static int cli_quitting = false;
+
 /**
  * Get next character from stdin, or EOF if got a SIGINT signal
  */
 static int interruptible_getc(void)
 {
+   if( cli_quitting )
+      return EOF;
+
    int r;
    char c;
 
    r = read(0, &c, 1); // read from stdin, will return -1 on SIGINT
+
+   if( r == -1 && errno == EINTR )
+      cli_quitting = true;
 
    return r == 1 ? c : EOF;
 }

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -9,6 +9,7 @@
 
 #ifdef HAVE_EDITLINE
 # include "editline.h"
+# include <signal.h>
 # ifdef WIN32
 #  include <io.h>
 # endif
@@ -53,21 +54,22 @@ void cli::send_notice( uint64_t callback_id, variants args /* = variants() */ )
    FC_ASSERT(false);
 }
 
-void cli::start()
-{
-   cli_commands() = get_method_names(0);
-
-#ifdef HAVE_EDITLINE
-el_hist_size = 256;
-#endif
-
-   _run_complete = fc::async( [&](){ run(); } );
-}
-
 void cli::stop()
 {
-   _run_complete.cancel();
+   cancel();
    _run_complete.wait();
+}
+
+void cli::cancel()
+{
+   _run_complete.cancel();
+#ifdef HAVE_EDITLINE
+   if( _getline_thread )
+   {
+      _getline_thread->signal(SIGINT);
+      _getline_thread = nullptr;
+   }
+#endif
 }
 
 void cli::wait()
@@ -103,6 +105,20 @@ void cli::run()
          }
          catch ( const fc::eof_exception& e )
          {
+            if( _getline_thread )
+            {
+               _getline_thread->quit();
+               _getline_thread = nullptr;
+            }
+            break;
+         }
+         catch ( const fc::canceled_exception& e )
+         {
+            if( _getline_thread )
+            {
+               _getline_thread->quit();
+               _getline_thread = nullptr;
+            }
             break;
          }
 
@@ -128,6 +144,11 @@ void cli::run()
 
          if (e.code() == fc::canceled_exception_code)
          {
+            if( _getline_thread )
+            {
+               _getline_thread->quit();
+               _getline_thread = nullptr;
+            }
             break;
          }
       }
@@ -237,6 +258,39 @@ static int cli_check_secret(const char *source)
    return 0;
 }
 
+/**
+ * Get next character from stdin, or EOF if got a SIGINT signal
+ */
+static int interruptable_getc(void)
+{
+   int r;
+   char c;
+
+   r = read(0, &c, 1); // read from stdin, will return -1 on SIGINT
+
+   return r == 1 ? c : EOF;
+}
+
+void cli::start()
+{
+
+#ifdef HAVE_EDITLINE
+   el_hist_size = 256;
+
+   rl_set_complete_func(my_rl_complete);
+   rl_set_list_possib_func(cli_completion);
+   rl_set_check_secret_func(cli_check_secret);
+   rl_set_getc_func(interruptable_getc);
+
+   static fc::thread getline_thread("getline");
+   _getline_thread = &getline_thread;
+
+   cli_commands() = get_method_names(0);
+#endif
+
+   _run_complete = fc::async( [&](){ run(); } );
+}
+
 /***
  * @brief Read input from the user
  * @param prompt the prompt to display
@@ -258,21 +312,19 @@ void cli::getline( const fc::string& prompt, fc::string& line)
    if( _isatty( _fileno( stdin ) ) )
 #endif
    {
-      rl_set_complete_func(my_rl_complete);
-      rl_set_list_possib_func(cli_completion);
-      rl_set_check_secret_func(cli_check_secret);
-
-      static fc::thread getline_thread("getline");
-      getline_thread.async( [&](){
-         char* line_read = nullptr;
-         std::cout.flush(); //readline doesn't use cin, so we must manually flush _out
-         line_read = readline(prompt.c_str());
-         if( line_read == nullptr )
-            FC_THROW_EXCEPTION( fc::eof_exception, "" );
-         line = line_read;
-         // we don't need here to add line in editline's history, cause it will be doubled
-         free(line_read);
-      }).wait();
+      if( _getline_thread )
+      {
+         _getline_thread->async( [&prompt,&line](){
+            char* line_read = nullptr;
+            std::cout.flush(); //readline doesn't use cin, so we must manually flush _out
+            line_read = readline(prompt.c_str());
+            if( line_read == nullptr )
+               FC_THROW_EXCEPTION( fc::eof_exception, "" );
+            line = line_read;
+            // we don't need here to add line in editline's history, cause it will be doubled
+            free(line_read);
+         }).wait();
+      }
    }
    else
 #endif
@@ -280,7 +332,6 @@ void cli::getline( const fc::string& prompt, fc::string& line)
       std::cout << prompt;
       // sync_call( cin_thread, [&](){ std::getline( *input_stream, line ); }, "getline");
       fc::getline( fc::cin, line );
-      return;
    }
 }
 

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -260,7 +260,7 @@ static int cli_check_secret(const char *source)
 /**
  * Get next character from stdin, or EOF if got a SIGINT signal
  */
-static int interruptable_getc(void)
+static int interruptible_getc(void)
 {
    int r;
    char c;
@@ -279,7 +279,7 @@ void cli::start()
    rl_set_complete_func(my_rl_complete);
    rl_set_list_possib_func(cli_completion);
    //rl_set_check_secret_func(cli_check_secret);
-   rl_set_getc_func(interruptable_getc);
+   rl_set_getc_func(interruptible_getc);
 
    static fc::thread getline_thread("getline");
    _getline_thread = &getline_thread;

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -105,20 +105,12 @@ void cli::run()
          }
          catch ( const fc::eof_exception& e )
          {
-            if( _getline_thread )
-            {
-               _getline_thread->quit();
-               _getline_thread = nullptr;
-            }
+            _getline_thread = nullptr;
             break;
          }
          catch ( const fc::canceled_exception& e )
          {
-            if( _getline_thread )
-            {
-               _getline_thread->quit();
-               _getline_thread = nullptr;
-            }
+            _getline_thread = nullptr;
             break;
          }
 
@@ -142,11 +134,7 @@ void cli::run()
       {
          if (e.code() == fc::canceled_exception_code)
          {
-            if( _getline_thread )
-            {
-               _getline_thread->quit();
-               _getline_thread = nullptr;
-            }
+            _getline_thread = nullptr;
             break;
          }
          std::cout << e.to_detail_string() << "\n";
@@ -257,6 +245,10 @@ static int cli_check_secret(const char *source)
    return 0;
 }
 
+/***
+ * Indicates whether CLI is quitting after got a SIGINT signal.
+ * In order to be used by editline which is C-style, this is a global variable.
+ */
 static int cli_quitting = false;
 
 /**
@@ -291,6 +283,8 @@ void cli::start()
 
    static fc::thread getline_thread("getline");
    _getline_thread = &getline_thread;
+
+   cli_quitting = false;
 
    cli_commands() = get_method_names(0);
 #endif

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -289,7 +289,7 @@ void cli::start()
    cli_commands() = get_method_names(0);
 #endif
 
-   _run_complete = fc::async( [&](){ run(); } );
+   _run_complete = fc::async( [this](){ run(); } );
 }
 
 /***

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -278,7 +278,7 @@ void cli::start()
 
    rl_set_complete_func(my_rl_complete);
    rl_set_list_possib_func(cli_completion);
-   rl_set_check_secret_func(cli_check_secret);
+   //rl_set_check_secret_func(cli_check_secret);
    rl_set_getc_func(interruptable_getc);
 
    static fc::thread getline_thread("getline");

--- a/src/rpc/websocket_api.cpp
+++ b/src/rpc/websocket_api.cpp
@@ -7,9 +7,11 @@ websocket_api_connection::~websocket_api_connection()
 {
 }
 
-websocket_api_connection::websocket_api_connection( fc::http::websocket_connection& c, uint32_t max_depth )
+websocket_api_connection::websocket_api_connection( const std::shared_ptr<fc::http::websocket_connection>& c,
+                                                    uint32_t max_depth )
    : api_connection(max_depth),_connection(c)
 {
+   FC_ASSERT( c );
    _rpc_state.add_method( "call", [this]( const variants& args ) -> variant
    {
       FC_ASSERT( args.size() == 3 && args[2].is_array() );
@@ -47,9 +49,9 @@ websocket_api_connection::websocket_api_connection( fc::http::websocket_connecti
       return this->receive_call( 0, method_name, args );
    } );
 
-   _connection.on_message_handler( [&]( const std::string& msg ){ on_message(msg,true); } );
-   _connection.on_http_handler( [&]( const std::string& msg ){ return on_message(msg,false); } );
-   _connection.closed.connect( [this](){ closed(); } );
+   _connection->on_message_handler( [this]( const std::string& msg ){ on_message(msg,true); } );
+   _connection->on_http_handler( [this]( const std::string& msg ){ return on_message(msg,false); } );
+   _connection->closed.connect( [this](){ closed(); } );
 }
 
 variant websocket_api_connection::send_call(
@@ -57,29 +59,43 @@ variant websocket_api_connection::send_call(
    string method_name,
    variants args /* = variants() */ )
 {
-   auto request = _rpc_state.start_remote_call(  "call", {api_id, std::move(method_name), std::move(args) } );
-   _connection.send_message( fc::json::to_string(fc::variant(request, _max_conversion_depth),
-                                                 fc::json::stringify_large_ints_and_doubles, _max_conversion_depth ) );
-   return _rpc_state.wait_for_response( *request.id );
+   if( _connection )
+   {
+      auto request = _rpc_state.start_remote_call( "call", { api_id, std::move(method_name), std::move(args) } );
+      _connection->send_message( fc::json::to_string( fc::variant( request, _max_conversion_depth ),
+                                                      fc::json::stringify_large_ints_and_doubles,
+                                                      _max_conversion_depth ) );
+      return _rpc_state.wait_for_response( *request.id );
+   }
+   return variant(); // TODO return an error
 }
 
 variant websocket_api_connection::send_callback(
    uint64_t callback_id,
    variants args /* = variants() */ )
 {
-   auto request = _rpc_state.start_remote_call( "callback", {callback_id, std::move(args) } );
-   _connection.send_message( fc::json::to_string(fc::variant(request, _max_conversion_depth),
-                                                 fc::json::stringify_large_ints_and_doubles, _max_conversion_depth ) );
-   return _rpc_state.wait_for_response( *request.id );
+   if( _connection )
+   {
+      auto request = _rpc_state.start_remote_call( "callback", { callback_id, std::move(args) } );
+      _connection->send_message( fc::json::to_string( fc::variant( request, _max_conversion_depth ),
+                                                      fc::json::stringify_large_ints_and_doubles,
+                                                      _max_conversion_depth ) );
+      return _rpc_state.wait_for_response( *request.id );
+   }
+   return variant(); // TODO return an error
 }
 
 void websocket_api_connection::send_notice(
    uint64_t callback_id,
    variants args /* = variants() */ )
 {
-   fc::rpc::request req{ optional<uint64_t>(), "notice", {callback_id, std::move(args)}};
-   _connection.send_message( fc::json::to_string(fc::variant(req, _max_conversion_depth),
-                                                 fc::json::stringify_large_ints_and_doubles, _max_conversion_depth ) );
+   if( _connection )
+   {
+      fc::rpc::request req{ optional<uint64_t>(), "notice", { callback_id, std::move(args) } };
+      _connection->send_message( fc::json::to_string( fc::variant( req, _max_conversion_depth ),
+                                                      fc::json::stringify_large_ints_and_doubles,
+                                                      _max_conversion_depth ) );
+   }
 }
 
 std::string websocket_api_connection::on_message(
@@ -117,8 +133,8 @@ std::string websocket_api_connection::on_message(
                if( call.id )
                {
                   auto reply = fc::json::to_string( response( *call.id, result, "2.0" ), fc::json::stringify_large_ints_and_doubles, _max_conversion_depth );
-                  if( send_message )
-                     _connection.send_message( reply );
+                  if( send_message && _connection )
+                     _connection->send_message( reply );
                   return reply;
                }
             }
@@ -135,8 +151,8 @@ std::string websocket_api_connection::on_message(
 
                auto reply = fc::json::to_string( variant(response( *call.id, error_object{ 1, optexcept->to_string(), fc::variant(*optexcept, _max_conversion_depth)}, "2.0" ), _max_conversion_depth ),
                                                  fc::json::stringify_large_ints_and_doubles, _max_conversion_depth );
-               if( send_message )
-                  _connection.send_message( reply );
+               if( send_message && _connection )
+                  _connection->send_message( reply );
 
                return reply;
          }

--- a/src/rpc/websocket_api.cpp
+++ b/src/rpc/websocket_api.cpp
@@ -125,14 +125,18 @@ std::string websocket_api_connection::on_message(
                auto end = time_point::now();
 
                if( end - start > fc::milliseconds( LOG_LONG_API_MAX_MS ) )
-                  elog( "API call execution time limit exceeded. method: ${m} params: ${p} time: ${t}", ("m",call.method)("p",call.params)("t", end - start) );
+                  elog( "API call execution time limit exceeded. method: ${m} params: ${p} time: ${t}",
+                        ("m",call.method)("p",call.params)("t", end - start) );
                else if( end - start > fc::milliseconds( LOG_LONG_API_WARN_MS ) )
-                  wlog( "API call execution time nearing limit. method: ${m} params: ${p} time: ${t}", ("m",call.method)("p",call.params)("t", end - start) );
+                  wlog( "API call execution time nearing limit. method: ${m} params: ${p} time: ${t}",
+                        ("m",call.method)("p",call.params)("t", end - start) );
 #endif
 
                if( call.id )
                {
-                  auto reply = fc::json::to_string( response( *call.id, result, "2.0" ), fc::json::stringify_large_ints_and_doubles, _max_conversion_depth );
+                  auto reply = fc::json::to_string( response( *call.id, result, "2.0" ),
+                                                    fc::json::stringify_large_ints_and_doubles,
+                                                    _max_conversion_depth );
                   if( send_message && _connection )
                      _connection->send_message( reply );
                   return reply;

--- a/src/thread/thread.cpp
+++ b/src/thread/thread.cpp
@@ -156,6 +156,17 @@ namespace fc {
 
    void          thread::debug( const fc::string& d ) { /*my->debug(d);*/ }
 
+#if defined(__linux__) || defined(__APPLE__)
+#include <signal.h>
+#endif
+
+   void thread::signal(int sig)
+   {
+#if defined(__linux__) || defined(__APPLE__)
+      pthread_kill( my->boost_thread->native_handle(), sig );
+#endif
+   }
+
   void thread::quit()
   {
     //if quitting from a different thread, start quit task on thread.

--- a/tests/api.cpp
+++ b/tests/api.cpp
@@ -61,7 +61,7 @@ int main( int argc, char** argv )
 
       fc::http::websocket_server server;
       server.on_connection([&]( const websocket_connection_ptr& c ){
-               auto wsc = std::make_shared<websocket_api_connection>(*c, MAX_DEPTH);
+               auto wsc = std::make_shared<websocket_api_connection>(c, MAX_DEPTH);
                auto login = std::make_shared<login_api>();
                login->calc = calc_api;
                wsc->register_api(fc::api<login_api>(login));
@@ -76,7 +76,7 @@ int main( int argc, char** argv )
          try { 
             fc::http::websocket_client client;
             auto con  = client.connect( "ws://localhost:8090" );
-            auto apic = std::make_shared<websocket_api_connection>(*con, MAX_DEPTH);
+            auto apic = std::make_shared<websocket_api_connection>(con, MAX_DEPTH);
             auto remote_login_api = apic->get_remote_api<login_api>();
             auto remote_calc = remote_login_api->get_calc();
             remote_calc->on_result( []( uint32_t r ) { elog( "callback result ${r}", ("r",r) ); } );


### PR DESCRIPTION
For https://github.com/bitshares/bitshares-core/issues/1690

<del>My opinion: don't merge this unless we've found a way to fix the side effects: https://github.com/bitshares/bitshares-core/pull/1695#issuecomment-479590794</del>
Update: already fixed the side effects along with some other CLI improvements, E.G.
* pressing TAB key will complete a command as long as possible
* Increased CLI command history buffer size to 256 (from 15)
* CLI no longer stores continuous duplicate commands to history, so no longer need to press UP key several times to find a different command
* pressing Ctrl+C will quit CLI cleanly at most time
* sending SIGINT or SIGTERM to CLI will terminate it cleanly at most time
* when CLI got disconnected by the API node, it will quit cleanly at most time

By the way,
* do you know we can press Ctrl+R to search in command history? Although it's a bit buggy.
* Do we want a feature that saves command history to a file e.g. on quit or on the fly and load it on next startup?