### PR TITLE
Add missing serialization for sha1

### DIFF
--- a/include/fc/crypto/sha1.hpp
+++ b/include/fc/crypto/sha1.hpp
@@ -67,6 +67,20 @@ class sha1
     uint32_t _hash[5]; 
 };
 
+namespace raw {
+
+   template<typename T>
+   inline void pack( T& ds, const sha1& ep, uint32_t _max_depth ) {
+      ds << ep;
+   }
+
+   template<typename T>
+   inline void unpack( T& ds, sha1& ep, uint32_t _max_depth ) {
+      ds >> ep;
+   }
+
+}
+
   class variant;
   void to_variant( const sha1& bi, variant& v, uint32_t max_depth );
   void from_variant( const variant& v, sha1& bi, uint32_t max_depth );


### PR DESCRIPTION
I started getting build errors after rebasing my work on bitshares/bitshares-core#1506 on top of the HTLC stuff, because the packer/unpacker for sha1 doesn't seem to exist. So I added them.