### PR TITLE
add user value for websocket_connection

### DIFF
--- a/include/fc/network/http/websocket.hpp
+++ b/include/fc/network/http/websocket.hpp
@@ -31,6 +31,9 @@ namespace fc { namespace http {
 
          virtual std::string get_request_header(const std::string& key) = 0;
 
+         virtual std::string find_user_value( const std::string& key ) = 0;
+         virtual void insert_user_value( const std::string& key, const std::string& value ) = 0;
+
          fc::signal<void()> closed;
       private:
          fc::any                                   _session_data;
@@ -38,6 +41,7 @@ namespace fc { namespace http {
          std::function<string(const std::string&)> _on_http;
    };
    typedef std::shared_ptr<websocket_connection> websocket_connection_ptr;
+   typedef std::weak_ptr<websocket_connection> websocket_connection_weak_ptr;
 
    typedef std::function<void(const websocket_connection_ptr&)> on_connection_handler;
 

--- a/include/fc/rpc/websocket_api.hpp
+++ b/include/fc/rpc/websocket_api.hpp
@@ -7,6 +7,9 @@
 
 namespace fc { namespace rpc {
 
+   const static std::string ws_compress_header = "WebSocket-Encoding";
+   const static std::string ws_compress_value = "deflate";
+
    class websocket_api_connection : public api_connection
    {
       public:

--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -1,3 +1,6 @@
+#include <map>
+#include <string>
+
 #include <fc/network/http/websocket.hpp>
 #include <websocketpp/config/asio_client.hpp>
 #include <websocketpp/config/asio.hpp>
@@ -183,12 +186,29 @@ namespace fc { namespace http {
                _ws_connection->close(code,reason);
             }
 
-            virtual std::string get_request_header(const std::string& key)override
+            virtual std::string get_request_header( const std::string& key )override
             {
               return _ws_connection->get_request_header(key);
             }
 
+            virtual std::string find_user_value( const std::string& key )override
+            {
+                auto it = _user_values.find(key);
+                if(it == _user_values.end())
+                {
+                    return "";
+                }
+
+                return (*it).second;
+            }
+
+            virtual void insert_user_value( const std::string& key, const std::string& value )override
+            {
+               _user_values[key] = value;
+            }
+
             T _ws_connection;
+            std::map<std::string, std::string>  _user_values;
       };
 
       typedef websocketpp::lib::shared_ptr<boost::asio::ssl::context> context_ptr;


### PR DESCRIPTION
I see bts cost very large traffic,Because not compress websocket frame.
And although websocket protocol define `permessage-deflate`, but some client not support.

So I add `insert_user_value` and `find_user_value` method for websocket_connection class, after do this, we can setting compress flag in our logic code. If user want compress websocket, it don't dependent on it's websocket library/protocol.

Do this work in bts , only add a new api `enable_compress` for `login_api`,  like this：https://github.com/IronsDu/bitshares-core/commit/4f688c0f38a61aef8e0cd19b3c0bb2907267818c.


    bool login_api::enable_compress() const
    {
        auto connection = _connection.lock();
        if (connection)
        {
            connection->append_header(fc::rpc::ws_compress_header, fc::rpc::ws_compress_value);
            return true;
        }
        return false;
    }

If we want compress websocket, we can call `enable_compress` api in my client code. 
Of cause, if we use compress, our client must decompression reply of server (DON'T forget).

@syalon Please introduce your test of this pr's change, and show some performance or network traffic optimize.