### PR TITLE
Add API support for optional arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
  - 'which build-wrapper-linux-x86-64 && build-wrapper-linux-x86-64 --out-dir bw-output make -j 2 || make -j 2'
  - set -o pipefail
  - tests/run-parallel-tests.sh tests/all_tests
- - "tests/api 2>&1 | grep -vE 'callback result 9|remote_calc->add. 4, 5 .: 9|set callback|] \\.$'"
+ - tests/api 2>&1 | cat
  - tests/hmac_test 2>&1 | cat
  - tests/ecc_test README.md 2>&1 | cat
  - 'find CMakeFiles/fc.dir -type d | while read d; do gcov -o "$d" "${d/CMakeFiles*.dir/./}"/*.cpp; done >/dev/null'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ script:
  - 'which build-wrapper-linux-x86-64 && build-wrapper-linux-x86-64 --out-dir bw-output make -j 2 || make -j 2'
  - set -o pipefail
  - tests/run-parallel-tests.sh tests/all_tests
- - tests/api 2>&1 | cat
  - tests/hmac_test 2>&1 | cat
  - tests/ecc_test README.md 2>&1 | cat
  - 'find CMakeFiles/fc.dir -type d | while read d; do gcov -o "$d" "${d/CMakeFiles*.dir/./}"/*.cpp; done >/dev/null'

--- a/include/fc/api.hpp
+++ b/include/fc/api.hpp
@@ -48,7 +48,7 @@ namespace fc {
            using type = short_pack<Types...>;
        };
        template<unsigned RemoveCount, typename T, typename... Types>
-       struct pack_cutter_impl<RemoveCount, std::enable_if_t<RemoveCount>, T, Types...>
+       struct pack_cutter_impl<RemoveCount, std::enable_if_t<RemoveCount != 0>, T, Types...>
                : public pack_cutter_impl<RemoveCount - 1, void, Types...> {};
        template<unsigned RemoveCount, typename... Types>
        struct pack_cutter : public pack_cutter_impl<RemoveCount, void, Types...> {};

--- a/include/fc/api.hpp
+++ b/include/fc/api.hpp
@@ -28,6 +28,9 @@ namespace fc {
     /// whereas normally the last two arguments must be provided, this template allows them to be omitted.
     /// Note that this only applies to trailing optional arguments, i.e. given a callable taking
     /// (fc::optional<int>, int, fc::optional<int>), only the last argument can be omitted.
+    ///
+    /// A discussion of how exactly this works is available here:
+    /// https://github.com/bitshares/bitshares-fc/pull/126#issuecomment-490566060
     template<typename R, typename... Parameters>
     struct optionals_callable : public std::function<R(Parameters...)> {
        using std::function<R(Parameters...)>::operator();

--- a/include/fc/network/http/websocket.hpp
+++ b/include/fc/network/http/websocket.hpp
@@ -50,7 +50,12 @@ namespace fc { namespace http {
          void on_connection( const on_connection_handler& handler);
          void listen( uint16_t port );
          void listen( const fc::ip::endpoint& ep );
+         uint16_t get_listening_port();
          void start_accept();
+
+         void stop_listening();
+         void close();
+         void synchronous_close();
 
       private:
          friend class detail::websocket_server_impl;
@@ -83,6 +88,9 @@ namespace fc { namespace http {
 
          websocket_connection_ptr connect( const std::string& uri );
          websocket_connection_ptr secure_connect( const std::string& uri );
+
+         void close();
+         void synchronous_close();
       private:
          std::unique_ptr<detail::websocket_client_impl> my;
          std::unique_ptr<detail::websocket_tls_client_impl> smy;

--- a/include/fc/network/http/websocket.hpp
+++ b/include/fc/network/http/websocket.hpp
@@ -55,7 +55,6 @@ namespace fc { namespace http {
 
          void stop_listening();
          void close();
-         void synchronous_close();
 
       private:
          friend class detail::websocket_server_impl;

--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -649,14 +649,6 @@ namespace fc { namespace http {
            my->_server.close(connection.first, websocketpp::close::status::normal, "Goodbye");
    }
 
-   void websocket_server::synchronous_close()
-   {
-      close();
-      if (my->_closed)
-         my->_closed->wait();
-   }
-
-
 
 
    websocket_tls_server::websocket_tls_server( const string& server_pem, const string& ssl_password ):my( new detail::websocket_tls_server_impl(server_pem, ssl_password) ) {}

--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -207,7 +207,7 @@ namespace fc { namespace http {
                     _server_thread.async( [&](){
                        auto new_con = std::make_shared<websocket_connection_impl<websocket_server_type::connection_ptr>>( _server.get_con_from_hdl(hdl) );
                        _on_connection( _connections[hdl] = new_con );
-                       if ( !_closed )
+                       if ( !_closed || _closed->ready() )
                           _closed = new fc::promise<void>();
                     }).wait();
                });
@@ -216,7 +216,6 @@ namespace fc { namespace http {
                        auto current_con = _connections.find(hdl);
                        assert( current_con != _connections.end() );
                        wdump(("server")(msg->get_payload()));
-                       //std::cerr<<"recv: "<<msg->get_payload()<<"\n";
                        auto payload = msg->get_payload();
                        std::shared_ptr<websocket_connection> con = current_con->second;
                        ++_pending_messages;

--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -207,8 +207,6 @@ namespace fc { namespace http {
                     _server_thread.async( [&](){
                        auto new_con = std::make_shared<websocket_connection_impl<websocket_server_type::connection_ptr>>( _server.get_con_from_hdl(hdl) );
                        _on_connection( _connections[hdl] = new_con );
-                       if ( !_closed || _closed->ready() )
-                          _closed = new fc::promise<void>();
                     }).wait();
                });
                _server.set_message_handler( [&]( connection_hdl hdl, websocket_server_type::message_ptr msg ){
@@ -290,6 +288,9 @@ namespace fc { namespace http {
             {
                if( _server.is_listening() )
                   _server.stop_listening();
+
+               if ( _connections.size() )
+                  _closed = new fc::promise<void>();
 
                auto cpy_con = _connections;
                for( auto item : cpy_con )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,3 @@
-
-add_executable( api api.cpp )
-target_link_libraries( api fc )
-
 if( ECC_IMPL STREQUAL secp256k1 )
     add_executable( blind all_tests.cpp crypto/blind.cpp )
     target_link_libraries( blind fc )
@@ -55,5 +51,6 @@ add_executable( all_tests all_tests.cpp
                           utf8_test.cpp
                           variant_test.cpp
                           logging_tests.cpp
+                          api_tests.cpp
                           )
 target_link_libraries( all_tests fc )

--- a/tests/api_tests.cpp
+++ b/tests/api_tests.cpp
@@ -77,24 +77,22 @@ BOOST_AUTO_TEST_CASE(login_test) {
       auto listen_port = server->get_listening_port();
       server->start_accept();
 
-      try {
-         auto client = std::make_shared<fc::http::websocket_client>();
-         auto con  = client->connect( "ws://localhost:" + std::to_string(listen_port) );
-         server->stop_listening();
-         auto apic = std::make_shared<websocket_api_connection>(con, MAX_DEPTH);
-         auto remote_login_api = apic->get_remote_api<login_api>();
-         auto remote_calc = remote_login_api->get_calc();
-         bool remote_triggered = false;
-         remote_calc->on_result( [&remote_triggered]( uint32_t r ) { remote_triggered = true; } );
-         BOOST_CHECK_EQUAL(remote_calc->add( 4, 5 ), 9);
-         BOOST_CHECK(remote_triggered);
+      auto client = std::make_shared<fc::http::websocket_client>();
+      auto con  = client->connect( "ws://localhost:" + std::to_string(listen_port) );
+      server->stop_listening();
+      auto apic = std::make_shared<websocket_api_connection>(con, MAX_DEPTH);
+      auto remote_login_api = apic->get_remote_api<login_api>();
+      auto remote_calc = remote_login_api->get_calc();
+      bool remote_triggered = false;
+      remote_calc->on_result( [&remote_triggered]( uint32_t r ) { remote_triggered = true; } );
+      BOOST_CHECK_EQUAL(remote_calc->add( 4, 5 ), 9);
+      BOOST_CHECK(remote_triggered);
 
-         client->synchronous_close();
-         server->close();
-         fc::usleep(fc::milliseconds(50));
-         client.reset();
-         server.reset();
-      } FC_LOG_AND_RETHROW()
+      client->synchronous_close();
+      server->close();
+      fc::usleep(fc::milliseconds(50));
+      client.reset();
+      server.reset();
    } FC_LOG_AND_RETHROW()
 }
 
@@ -118,24 +116,22 @@ BOOST_AUTO_TEST_CASE(optionals_test) {
       auto listen_port = server->get_listening_port();
       server->start_accept();
 
-      try {
-         auto client = std::make_shared<fc::http::websocket_client>();
-         auto con  = client->connect( "ws://localhost:" + std::to_string(listen_port) );
-         server->stop_listening();
-         auto apic = std::make_shared<websocket_api_connection>(*con, MAX_DEPTH);
-         auto remote_optionals = apic->get_remote_api<optionals_api>();
+      auto client = std::make_shared<fc::http::websocket_client>();
+      auto con  = client->connect( "ws://localhost:" + std::to_string(listen_port) );
+      server->stop_listening();
+      auto apic = std::make_shared<websocket_api_connection>(*con, MAX_DEPTH);
+      auto remote_optionals = apic->get_remote_api<optionals_api>();
 
-         BOOST_CHECK_EQUAL(remote_optionals->foo("a"), "[\"a\",null,null]");
-         BOOST_CHECK_EQUAL(remote_optionals->foo("a", "b"), "[\"a\",\"b\",null]");
-         BOOST_CHECK_EQUAL(remote_optionals->foo("a", "b", "c"), "[\"a\",\"b\",\"c\"]");
-         BOOST_CHECK_EQUAL(remote_optionals->foo("a", {}, "c"), "[\"a\",null,\"c\"]");
+      BOOST_CHECK_EQUAL(remote_optionals->foo("a"), "[\"a\",null,null]");
+      BOOST_CHECK_EQUAL(remote_optionals->foo("a", "b"), "[\"a\",\"b\",null]");
+      BOOST_CHECK_EQUAL(remote_optionals->foo("a", "b", "c"), "[\"a\",\"b\",\"c\"]");
+      BOOST_CHECK_EQUAL(remote_optionals->foo("a", {}, "c"), "[\"a\",null,\"c\"]");
 
-         client->synchronous_close();
-         server->close();
-         fc::usleep(fc::milliseconds(50));
-         client.reset();
-         server.reset();
-      } FC_LOG_AND_RETHROW()
+      client->synchronous_close();
+      server->close();
+      fc::usleep(fc::milliseconds(50));
+      client.reset();
+      server.reset();
    } FC_LOG_AND_RETHROW()
 }
 

--- a/tests/api_tests.cpp
+++ b/tests/api_tests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(login_test) {
          BOOST_CHECK(remote_triggered);
 
          client->synchronous_close();
-         server->synchronous_close();
+         server->close();
          fc::usleep(fc::milliseconds(50));
          client.reset();
          server.reset();
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(optionals_test) {
          BOOST_CHECK_EQUAL(remote_optionals->foo("a", {}, "c"), "[\"a\",null,\"c\"]");
 
          client->synchronous_close();
-         server->synchronous_close();
+         server->close();
          fc::usleep(fc::milliseconds(50));
          client.reset();
          server.reset();

--- a/tests/api_tests.cpp
+++ b/tests/api_tests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(optionals_test) {
 
       auto server = std::make_shared<fc::http::websocket_server>();
       server->on_connection([&]( const websocket_connection_ptr& c ){
-               auto wsc = std::make_shared<websocket_api_connection>(*c, MAX_DEPTH);
+               auto wsc = std::make_shared<websocket_api_connection>(c, MAX_DEPTH);
                wsc->register_api(fc::api<optionals_api>(optionals));
                c->set_session_data( wsc );
           });
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(optionals_test) {
       auto client = std::make_shared<fc::http::websocket_client>();
       auto con  = client->connect( "ws://localhost:" + std::to_string(listen_port) );
       server->stop_listening();
-      auto apic = std::make_shared<websocket_api_connection>(*con, MAX_DEPTH);
+      auto apic = std::make_shared<websocket_api_connection>(con, MAX_DEPTH);
       auto remote_optionals = apic->get_remote_api<optionals_api>();
 
       BOOST_CHECK_EQUAL(remote_optionals->foo("a"), "[\"a\",null,null]");

--- a/tests/api_tests.cpp
+++ b/tests/api_tests.cpp
@@ -73,12 +73,14 @@ BOOST_AUTO_TEST_CASE(login_test) {
                c->set_session_data( wsc );
           });
 
-      server->listen( 8090 );
+      server->listen( 0 );
+      auto listen_port = server->get_listening_port();
       server->start_accept();
 
       try {
          auto client = std::make_shared<fc::http::websocket_client>();
-         auto con  = client->connect( "ws://localhost:8090" );
+         auto con  = client->connect( "ws://localhost:" + std::to_string(listen_port) );
+         server->stop_listening();
          auto apic = std::make_shared<websocket_api_connection>(con, MAX_DEPTH);
          auto remote_login_api = apic->get_remote_api<login_api>();
          auto remote_calc = remote_login_api->get_calc();
@@ -87,8 +89,10 @@ BOOST_AUTO_TEST_CASE(login_test) {
          BOOST_CHECK_EQUAL(remote_calc->add( 4, 5 ), 9);
          BOOST_CHECK(remote_triggered);
 
+         client->synchronous_close();
+         server->synchronous_close();
+         fc::usleep(fc::milliseconds(50));
          client.reset();
-         fc::usleep(fc::milliseconds(100));
          server.reset();
       } FC_LOG_AND_RETHROW()
    } FC_LOG_AND_RETHROW()
@@ -110,12 +114,14 @@ BOOST_AUTO_TEST_CASE(optionals_test) {
                c->set_session_data( wsc );
           });
 
-      server->listen( 8090 );
+      server->listen( 0 );
+      auto listen_port = server->get_listening_port();
       server->start_accept();
 
       try {
          auto client = std::make_shared<fc::http::websocket_client>();
-         auto con  = client->connect( "ws://localhost:8090" );
+         auto con  = client->connect( "ws://localhost:" + std::to_string(listen_port) );
+         server->stop_listening();
          auto apic = std::make_shared<websocket_api_connection>(*con, MAX_DEPTH);
          auto remote_optionals = apic->get_remote_api<optionals_api>();
 
@@ -124,8 +130,10 @@ BOOST_AUTO_TEST_CASE(optionals_test) {
          BOOST_CHECK_EQUAL(remote_optionals->foo("a", "b", "c"), "[\"a\",\"b\",\"c\"]");
          BOOST_CHECK_EQUAL(remote_optionals->foo("a", {}, "c"), "[\"a\",null,\"c\"]");
 
+         client->synchronous_close();
+         server->synchronous_close();
+         fc::usleep(fc::milliseconds(50));
          client.reset();
-         fc::usleep(fc::milliseconds(100));
          server.reset();
       } FC_LOG_AND_RETHROW()
    } FC_LOG_AND_RETHROW()

--- a/tests/network/http/websocket_test.cpp
+++ b/tests/network/http/websocket_test.cpp
@@ -20,21 +20,8 @@ BOOST_AUTO_TEST_CASE(websocket_test)
                 });
             });
 
-        bool listen_ok = false;
-        for( int i = 0; !listen_ok && i < 5; ++i )
-        {
-           port = std::rand() % 50000 + 10000;
-           try
-           {
-              server.listen( port );
-              listen_ok = true;
-           }
-           catch( std::exception& ignore )
-           {
-              // if the port is busy, listen() will throw a std::exception, do nothing here.
-           }
-        }
-        BOOST_REQUIRE( listen_ok );
+        server.listen( 0 );
+        port = server.get_listening_port();
 
         server.start_accept();
 
@@ -44,49 +31,27 @@ BOOST_AUTO_TEST_CASE(websocket_test)
                     echo = s;
                 });
         c_conn->send_message( "hello world" );
-        fc::usleep( fc::seconds(1) );
+        fc::usleep( fc::milliseconds(100) );
         BOOST_CHECK_EQUAL("echo: hello world", echo);
         c_conn->send_message( "again" );
-        fc::usleep( fc::seconds(1) );
+        fc::usleep( fc::milliseconds(100) );
         BOOST_CHECK_EQUAL("echo: again", echo);
 
         s_conn->close(0, "test");
-        fc::usleep( fc::seconds(1) );
-        try {
-            c_conn->send_message( "again" );
-            BOOST_FAIL("expected assertion failure");
-        } catch (const fc::exception& e) {
-            //std::cerr << e.to_string() << "\n";
-        }
+        fc::usleep( fc::milliseconds(100) );
+        BOOST_CHECK_THROW(c_conn->send_message( "again" ), fc::exception);
 
         c_conn = client.connect( "ws://localhost:" + fc::to_string(port) );
         c_conn->on_message_handler([&](const std::string& s){
                     echo = s;
                 });
         c_conn->send_message( "hello world" );
-        fc::usleep( fc::seconds(1) );
+        fc::usleep( fc::milliseconds(100) );
         BOOST_CHECK_EQUAL("echo: hello world", echo);
     }
 
-    try {
-        c_conn->send_message( "again" );
-        BOOST_FAIL("expected assertion failure");
-    } catch (const fc::assert_exception& e) {
-        std::cerr << "Expected assertion failure : " << e.to_string() << "\n";
-    } catch (const fc::exception& e) {
-        BOOST_FAIL("Unexpected exception : " + e.to_string());
-    } catch (const std::exception& e) {
-        BOOST_FAIL("Unexpected exception : " + std::string(e.what()));
-    }
-
-    try {
-        c_conn = client.connect( "ws://localhost:" + fc::to_string(port) );
-        BOOST_FAIL("expected fc::exception (fail to connect)");
-    } catch (const fc::exception& e) {
-        std::cerr << "Excepted fc::exception : " << e.to_string() << "\n";
-    } catch (const std::exception& e) {
-        BOOST_FAIL("Unexpected exception : " + std::string(e.what()));
-    }
+    BOOST_CHECK_THROW(c_conn->send_message( "again" ), fc::assert_exception);
+    BOOST_CHECK_THROW(client.connect( "ws://localhost:" + fc::to_string(port) ), fc::exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
FC_API now supports optional arguments! Any trailing arguments of
an fc::optional type are now optional, and do not need to be
supplied. If omitted, they will be inferred to be null optionals.

Note that I have not made the `binary_api_connection` support optional arguments. This is never used, and thus I didn't feel it was worth the effort. We might consider removing `binary_api_connection` entirely.