### PR TITLE
CLI improvements

### DIFF
--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -9,6 +9,7 @@
 
 #ifdef HAVE_EDITLINE
 # include "editline.h"
+# define CONFIG_UNIQUE_HISTORY // don't store the new command to history if it is identical to the last command
 # ifdef WIN32
 #  include <io.h>
 # endif

--- a/src/rpc/cli.cpp
+++ b/src/rpc/cli.cpp
@@ -56,6 +56,11 @@ void cli::send_notice( uint64_t callback_id, variants args /* = variants() */ )
 void cli::start()
 {
    cli_commands() = get_method_names(0);
+
+#ifdef HAVE_EDITLINE
+el_hist_size = 256;
+#endif
+
    _run_complete = fc::async( [&](){ run(); } );
 }
 


### PR DESCRIPTION
1. improve CLI tab completion feature

For example, if there are 3 commands: "gethelp", "get_account" and "get_account_name",
input "ge" then press TAB, the command will be completed to "get"; (this is new)
press TAB again, a list with all 3 commands will show;
input "get_ac" then press TAB, the command will be completed to "get_account";  (this is new)
press TAB again, a list with "get_account" and "get_account_name" will show.

