### PR TITLE
Fix memory leak. Not all tasks are deleted in thread_d dtor.

### DIFF
--- a/src/thread/thread.cpp
+++ b/src/thread/thread.cpp
@@ -114,8 +114,10 @@ namespace fc {
    }
 
    thread::~thread() {
-      if( my )
+      if( my && is_running() )
+      {
         quit();
+      }
 
       delete my;
    }
@@ -342,6 +344,10 @@ namespace fc {
 
    void thread::async_task( task_base* t, const priority& p, const time_point& tp ) {
       assert(my);
+      if ( !is_running() )
+      {
+         FC_THROW_EXCEPTION( canceled_exception, "Thread is not running.");
+      }
       t->_when = tp;
       task_base* stale_head = my->task_in_queue.load(boost::memory_order_relaxed);
       do { t->_next = stale_head;

--- a/src/thread/thread_d.hpp
+++ b/src/thread/thread_d.hpp
@@ -55,7 +55,14 @@ namespace fc {
               current = nullptr;
               fc::context* temp;
               for (fc::context* ready_context : ready_heap)
-                delete ready_context;
+              {
+                  if (ready_context->cur_task)
+                  {
+                     ready_context->cur_task->release();
+                     ready_context->cur_task = nullptr;
+                  }
+                  delete ready_context;
+              }
               ready_heap.clear();
               while (blocked)
               {
@@ -524,10 +531,10 @@ namespace fc {
 
               next->_set_active_context( current );
               current->cur_task = next;
-              next->run();
+              fc::shared_ptr<task_base> next_ptr(next);
+              next_ptr->run();
               current->cur_task = 0;
-              next->_set_active_context(0);
-              next->release();
+              next_ptr->_set_active_context(0);
               current->reinitialize();
            }
 


### PR DESCRIPTION
In thread::quit()
{
 ...
 my->start_next_fiber(true)
 ... 
}
my->start_next_fiber(true) - an exception is raised from here  and a context has yet a pointer to the task that will never released and memory will not freed.
So to avoid such situation in ~thread_d() lets release it.
to reproduce run: --tool=memcheck --leak-check=full ./all_tests -t thread_tests