### PR TITLE
Update CMake to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,10 +292,6 @@ if(WIN32)
 endif(WIN32)
 # end editline stuff
 
-if( NOT CPP_STANDARD )
-  set( CPP_STANDARD "-std=c++11" )
-endif()
-
 IF(WIN32)
   target_compile_definitions(fc PUBLIC WIN32 NOMINMAX _WIN32_WINNT=0x0501 _CRT_SECURE_NO_WARNINGS
     _SCL_SERCURE_NO_WARNINGS
@@ -317,12 +313,12 @@ ELSE()
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall")
 
   IF(APPLE)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPP_STANDARD} -stdlib=libc++ -Wall")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wall")
   ELSE()
     if( NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
-      target_compile_options(fc PUBLIC ${CPP_STANDARD} -Wall -fnon-call-exceptions)
+      target_compile_options(fc PUBLIC -Wall -fnon-call-exceptions)
     endif()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CPP_STANDARD} -Wall -fnon-call-exceptions")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fnon-call-exceptions")
 
     if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
         if( CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.0.0 OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.0.0 )


### PR DESCRIPTION
This PR changes the CMakeLists.txt file to use C++14, and removes references to C++11.

<del>This also fixes a POSIX / Windows incompatibility in a function that Windows does not use.</del> (Update: see #132)

NOTE: Separate issue: To compile FC alone on Windows, the CMakeModules/FindBoost.cmake needs to be deleted. Compiling as part of bitshares-core ignores that file. FindBoost.cmake should probably be permanently removed once we handle the pthread/boost/fc issue.