### PR TITLE
Fix websocket client crash on quit

### DIFF
--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -440,7 +440,8 @@ namespace fc { namespace http {
             :_client_thread( fc::thread::current() )
             {
                 _client.clear_access_channels( websocketpp::log::alevel::all );
-                _client.set_message_handler( [&]( connection_hdl hdl, typename websocketpp::client<T>::message_ptr msg ){
+                _client.set_message_handler( [&]( connection_hdl hdl,
+                                                  typename websocketpp::client<T>::message_ptr msg ){
                    _client_thread.async( [&](){
                         wdump((msg->get_payload()));
                         //std::cerr<<"recv: "<<msg->get_payload()<<"\n";

--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -471,12 +471,13 @@ namespace fc { namespace http {
             }
             ~websocket_client_impl()
             {
-               if(_connection )
+               if( _connection )
                {
                   _connection->close(0, "client closed");
                   _connection.reset();
-                  _closed->wait();
                }
+               if( _closed )
+                  _closed->wait();
             }
             fc::promise<void>::ptr             _connected;
             fc::promise<void>::ptr             _closed;


### PR DESCRIPTION
Fixed a crash-on-quit issue, see https://github.com/bitshares/bitshares-core/pull/1695#issuecomment-495885624.

By the way, refactored `websocket_client_impl` class and `websocket_tls_client_impl` class, moved duplicate code to a template class.