### PR TITLE
Correctly close websocket API connection

### DIFF
--- a/src/rpc/websocket_api.cpp
+++ b/src/rpc/websocket_api.cpp
@@ -74,7 +74,10 @@ websocket_api_connection::websocket_api_connection( const std::shared_ptr<fc::ht
 
        return result;
    } );
-   _connection->closed.connect( [this](){ closed(); } );
+   _connection->closed.connect( [this](){
+      closed();
+      _connection = nullptr;
+   } );
 }
 
 variant websocket_api_connection::send_call(


### PR DESCRIPTION
The `websocket_api_connection` object and `websocket_connection` object each holds a `shared_ptr` to the other. This PR release one of the `shared_ptr` when the connection is closed, so the destructor functions would be called.

For https://github.com/bitshares/bitshares-core/issues/1852.