### PR TITLE
Increase size for Boost 1.70

### DIFF
--- a/include/fc/network/tcp_socket.hpp
+++ b/include/fc/network/tcp_socket.hpp
@@ -51,7 +51,7 @@ namespace fc {
       friend class tcp_server;
       class impl;
       #ifdef _WIN64
-      fc::fwd<impl,0x98> my;
+      fc::fwd<impl,0xa8> my;
       #else
       fc::fwd<impl,0x54> my;
       #endif


### PR DESCRIPTION
The size of the tcp_socket impl must be increased in Windows in order to compile with Boost 1.70.