### PR TITLE
Replace improper static_variant operator overloads with comparators

### DIFF
--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -41,7 +41,7 @@ namespace fc {
          return n.c_str();  
      } 
   };
-  template<typename T> struct get_typename<flat_set<T>>   
+  template<typename T, typename... A> struct get_typename<flat_set<T, A...>>
   { 
      static const char* name()  { 
          static std::string n = std::string("flat_set<") + get_typename<T>::name() + ">"; 

--- a/include/fc/reflect/typename.hpp
+++ b/include/fc/reflect/typename.hpp
@@ -12,6 +12,7 @@
 #include <fc/container/flat_fwd.hpp>
 
 namespace fc {
+  template<typename...> class static_variant;
   class value;
   class exception;
   namespace ip { class address; }
@@ -41,10 +42,19 @@ namespace fc {
          return n.c_str();  
      } 
   };
-  template<typename T, typename... A> struct get_typename<flat_set<T, A...>>
+  template<typename T> struct get_typename<flat_set<T>>
+  {
+     static const char* name()  {
+         static std::string n = std::string("flat_set<") + get_typename<T>::name() + ">";
+         return n.c_str();
+     }
+  };
+  template<typename... Ts>
+  struct get_typename<flat_set<static_variant<Ts...>, typename static_variant<Ts...>::type_lt>>
   { 
      static const char* name()  { 
-         static std::string n = std::string("flat_set<") + get_typename<T>::name() + ">"; 
+         using TN = get_typename<static_variant<Ts...>>;
+         static std::string n = std::string("flat_set<") + TN::name() + ", " + TN::name() + "::type_lt>";
          return n.c_str();  
      } 
   };

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -302,6 +302,14 @@ public:
        static constexpr int value = impl::position<X, Types...>::pos;
     };
 
+    struct type_lt {
+       bool operator()(const static_variant& a, const static_variant& b) const { return a.which() < b.which(); }
+    };
+    struct type_eq {
+       bool operator()(const static_variant& a, const static_variant& b) const { return a.which() == b.which(); }
+    };
+    using flat_set_type = flat_set<static_variant, type_lt>;
+
     static_variant()
     {
         init_from_tag(0);
@@ -351,14 +359,6 @@ public:
        clean();
        v.visit( impl::move_construct<static_variant>(*this) );
        return *this;
-    }
-    friend bool operator == ( const static_variant& a, const static_variant& b )
-    {
-       return a.which() == b.which();
-    }
-    friend bool operator < ( const static_variant& a, const static_variant& b )
-    {
-       return a.which() < b.which();
     }
 
     template<typename X, typename = type_in_typelist<X>>

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -182,7 +182,10 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
 
       from_variant( v, sv1, nested_levels + 2 );
 
-      BOOST_CHECK( decltype(sv)::type_eq()(sv, sv1) );
+      auto sv_equal = [](const fc::static_variant<fc::test::item>& v1, const fc::static_variant<fc::test::item>& v2) {
+         return v1.get<fc::test::item>() == v2.get<fc::test::item>();
+      };
+      BOOST_CHECK( sv_equal(sv, sv1) );
 
       // both log and dump should never throw
       BOOST_TEST_MESSAGE( "========== About to log static_variant. ==========" );
@@ -215,7 +218,7 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
 
       from_variant( v, vec1, nested_levels + 3 );
 
-      BOOST_CHECK( std::equal(vec.begin(), vec.end(), vec1.begin(), decltype(vec)::value_type::type_eq()) );
+      BOOST_CHECK( std::equal(vec.begin(), vec.end(), vec1.begin(), sv_equal) );
 
       // both log and dump should never throw
       BOOST_TEST_MESSAGE( "========== About to log vector. ==========" );

--- a/tests/variant_test.cpp
+++ b/tests/variant_test.cpp
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
 
       from_variant( v, sv1, nested_levels + 2 );
 
-      BOOST_CHECK( sv == sv1 );
+      BOOST_CHECK( decltype(sv)::type_eq()(sv, sv1) );
 
       // both log and dump should never throw
       BOOST_TEST_MESSAGE( "========== About to log static_variant. ==========" );
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE( nested_objects_test )
 
       from_variant( v, vec1, nested_levels + 3 );
 
-      BOOST_CHECK( vec == vec1 );
+      BOOST_CHECK( std::equal(vec.begin(), vec.end(), vec1.begin(), decltype(vec)::value_type::type_eq()) );
 
       // both log and dump should never throw
       BOOST_TEST_MESSAGE( "========== About to log vector. ==========" );


### PR DESCRIPTION
`static_variant` provided operator overloads for == and < which compared only the types and not the values. This was used to make it easier to place `static_variant` types into `flat_set`s, but it constitutes a dangerous abuse of C++ operator overloading as code could accidentally be written using these operators and expecting them to be correctly implemented. Such code would be invisibly wrong. Removing these overloads eliminates this risk.

This commit removes the overloads and replaces them with comparator structs, and also provides a convenient type alias for a `flat_set` of `static_variant` types.

Requisite changes in BitShares are visible [here](https://github.com/nathanhourt/bitshares-2/commit/3a57465259f32f0894fe578cf2c661de3de1fba0) and will be PReq'd after this is merged.