### PR TITLE
Fix warnings

### DIFF
--- a/include/fc/log/appender.hpp
+++ b/include/fc/log/appender.hpp
@@ -34,6 +34,7 @@ namespace fc {
             return register_appender( type, appender_factory::ptr( new detail::appender_factory_impl<T>() ) );
          }
 
+         virtual ~appender() = default;
          static appender::ptr create( const std::string& name, const std::string& type, const variant& args  );
          static appender::ptr get( const std::string& name );
          static bool          register_appender( const std::string& type, const appender_factory::ptr& f );


### PR DESCRIPTION
Ref bitshares/bitshares-core#1584

The `appender` class is intended to be inherited and used polymorphically, but does not have a virtual destructor, which causes warnings. This adds a virtual destructor to fix these warnings.