### PR TITLE
Copy safety

### DIFF
--- a/include/fc/crypto/openssl.hpp
+++ b/include/fc/crypto/openssl.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <openssl/ec.h>
 #include <openssl/crypto.h>
+#include <openssl/dh.h>
 #include <openssl/evp.h>
 #include <openssl/conf.h>
 #include <openssl/err.h>
@@ -21,6 +22,8 @@ namespace fc
     struct ssl_wrapper
     {
         ssl_wrapper(ssl_type* obj):obj(obj) {}
+        ssl_wrapper( ssl_wrapper& copy ) = delete;
+        ssl_wrapper& operator=( ssl_wrapper& copy ) = delete;
 
         operator ssl_type*() { return obj; }
         operator const ssl_type*() const { return obj; }
@@ -30,23 +33,21 @@ namespace fc
         ssl_type* obj;
     };
 
-    #define SSL_TYPE(name, ssl_type, free_func) \
+    #define SSL_TYPE_DECL(name, ssl_type) \
         struct name  : public ssl_wrapper<ssl_type> \
         { \
-            name(ssl_type* obj=nullptr) \
-              : ssl_wrapper(obj) {} \
-            ~name() \
-            { \
-                if( obj != nullptr ) \
-                free_func(obj); \
-            } \
+            name( ssl_type* obj=nullptr ); \
+            name( name&& move ); \
+            ~name(); \
+            name& operator=( name&& move ); \
         };
 
-    SSL_TYPE(ec_group,       EC_GROUP,       EC_GROUP_free)
-    SSL_TYPE(ec_point,       EC_POINT,       EC_POINT_free)
-    SSL_TYPE(ecdsa_sig,      ECDSA_SIG,      ECDSA_SIG_free)
-    SSL_TYPE(bn_ctx,         BN_CTX,         BN_CTX_free)
-    SSL_TYPE(evp_cipher_ctx, EVP_CIPHER_CTX, EVP_CIPHER_CTX_free )
+    SSL_TYPE_DECL(ec_group,       EC_GROUP)
+    SSL_TYPE_DECL(ec_point,       EC_POINT)
+    SSL_TYPE_DECL(ecdsa_sig,      ECDSA_SIG)
+    SSL_TYPE_DECL(bn_ctx,         BN_CTX)
+    SSL_TYPE_DECL(evp_cipher_ctx, EVP_CIPHER_CTX)
+    SSL_TYPE_DECL(ssl_dh,         DH)
 
     /** allocates a bignum by default.. */
     struct ssl_bignum : public ssl_wrapper<BIGNUM>

--- a/include/fc/network/tcp_socket.hpp
+++ b/include/fc/network/tcp_socket.hpp
@@ -12,7 +12,9 @@ namespace fc {
   {
     public:
       tcp_socket();
+      tcp_socket( tcp_socket& copy ) = delete;
       ~tcp_socket();
+      tcp_socket& operator=( tcp_socket& copy ) = delete;
 
       void     connect_to( const fc::ip::endpoint& remote_endpoint );
       void     bind( const fc::ip::endpoint& local_endpoint );

--- a/src/crypto/dh.cpp
+++ b/src/crypto/dh.cpp
@@ -1,12 +1,9 @@
 #include <fc/crypto/dh.hpp>
-#include <openssl/dh.h>
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 #endif
 
 namespace fc {
-    SSL_TYPE(ssl_dh, DH, DH_free)
-
     static bool validate( const ssl_dh& dh, bool& valid ) {
         int check;
         DH_check(dh,&check);
@@ -36,7 +33,7 @@ namespace fc {
    {
         if( !p.size() ) 
             return valid = false;
-        ssl_dh dh = DH_new();
+        ssl_dh dh(DH_new());
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
         const auto bn_p = BN_bin2bn( (unsigned char*)&p.front(), p.size(), NULL );
         const auto bn_g = BN_bin2bn( (unsigned char*)&g, 1, NULL );
@@ -52,7 +49,7 @@ namespace fc {
    {
         if( !p.size() ) 
             return valid = false;
-        ssl_dh dh = DH_new();
+        ssl_dh dh(DH_new());
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
         const auto bn_p = BN_bin2bn( (unsigned char*)&p.front(), p.size(), NULL );
         const auto bn_g = BN_bin2bn( (unsigned char*)&g, 1, NULL );
@@ -90,7 +87,7 @@ namespace fc {
         return true;
    }
    bool diffie_hellman::compute_shared_key( const char* buf, uint32_t s ) {
-        ssl_dh dh = DH_new();
+        ssl_dh dh(DH_new());
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
         auto bn_p = BN_bin2bn( (unsigned char*)&p.front(), p.size(), NULL );
         auto bn_pub_key = BN_bin2bn( (unsigned char*)&pub_key.front(), pub_key.size(), NULL );

--- a/src/crypto/openssl.cpp
+++ b/src/crypto/openssl.cpp
@@ -63,4 +63,34 @@ namespace  fc
       static openssl_scope ossl;
       return 0;
     }
+
+    #define SSL_TYPE_IMPL(name, ssl_type, free_func) \
+            name::name( ssl_type* obj ) : ssl_wrapper(obj) {} \
+            name::name( name&& move ) : ssl_wrapper( move.obj ) \
+            { \
+               move.obj = nullptr; \
+            } \
+            name::~name() \
+            { \
+               if( obj != nullptr ) \
+                  free_func(obj); \
+            } \
+            name& name::operator=( name&& move ) \
+            { \
+               if( this != &move ) \
+               { \
+                  if( obj != nullptr ) \
+                     free_func(obj); \
+                  obj = move.obj; \
+                  move.obj = nullptr; \
+               } \
+               return *this; \
+            }
+
+    SSL_TYPE_IMPL(ec_group,       EC_GROUP,       EC_GROUP_free)
+    SSL_TYPE_IMPL(ec_point,       EC_POINT,       EC_POINT_free)
+    SSL_TYPE_IMPL(ecdsa_sig,      ECDSA_SIG,      ECDSA_SIG_free)
+    SSL_TYPE_IMPL(bn_ctx,         BN_CTX,         BN_CTX_free)
+    SSL_TYPE_IMPL(evp_cipher_ctx, EVP_CIPHER_CTX, EVP_CIPHER_CTX_free )
+    SSL_TYPE_IMPL(ssl_dh,         DH,             DH_free)
 }


### PR DESCRIPTION
Make sure openssl type wrappers and tcp_sockets are not copy-constructed or copy-assigned.
(Moved here from #165 )