### PR TITLE
Make for-core-3-3 branch mergable with master

### DIFF
--- a/include/fc/container/zeroed_array.hpp
+++ b/include/fc/container/zeroed_array.hpp
@@ -72,3 +72,9 @@ namespace fc {
       }
    }
 }
+
+namespace std {
+   template<>
+   template< typename T, size_t N >
+   class tuple_size< fc::zero_initialized_array< T, N > > : public tuple_size< array< T, N > > {};
+}


### PR DESCRIPTION
One change in master is incompatible with the new `zero_initialized_array`. This PR adds a necessary class template.