### PR TITLE
Fix failed stacktrace test

### DIFF
--- a/tests/stacktrace_test.cpp
+++ b/tests/stacktrace_test.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(static_variant_depth_test)
    for( const auto& line : lines )
       if( line.find("_svdt_visitor") != std::string::npos ) count++;
    BOOST_CHECK_LT( 2, count ); // test.visit(), static_variant::visit, function object, visitor
-   BOOST_CHECK_GT( 8, count ); // some is implementation-dependent
+   BOOST_CHECK_GT( 10, count ); // some is implementation-dependent
 }
 #endif
 


### PR DESCRIPTION
The result is platform / version dependent. Increase the range to avoid failure on Ubuntu 18.04 / Boost 1.69 / g++ 7.4.0