### PR TITLE
Fix warning in zeroed_array.hpp

### DIFF
--- a/include/fc/container/zeroed_array.hpp
+++ b/include/fc/container/zeroed_array.hpp
@@ -74,7 +74,6 @@ namespace fc {
 }
 
 namespace std {
-   template<>
    template< typename T, size_t N >
    class tuple_size< fc::zero_initialized_array< T, N > > : public tuple_size< array< T, N > > {};
 }


### PR DESCRIPTION
Only one template declaration is needed here, I think. Clang gives many, many warnings over it.