### PR TITLE
Fix Build for boost 1.72.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,7 +350,7 @@ elseif(WIN32 AND MINGW)
 endif()
 
 
-IF(NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY MATCHES "\\.(a|lib)$")
+IF(Boost_UNIT_TEST_FRAMEWORK_LIBRARY MATCHES "\\.(so|dll)$")
 IF(MSVC)
 add_definitions(/DBOOST_TEST_DYN_LINK)
 ELSE(MSVC)


### PR DESCRIPTION
Definitely something strange going on here, as in my environment
the value of Boost_UNIT_TEST_FRAMEWORK_LIBRARY is
"Boost::unit_test_framework"... So this is my fix, but probably
something else should be done.

Boost 1.72.0