### PR TITLE
FC updates to support Tanks and Taps 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ set( fc_sources
      src/crypto/hex.cpp
      src/crypto/sha1.cpp
      src/crypto/ripemd160.cpp
+     src/crypto/hash160.cpp
      src/crypto/sha256.cpp
      src/crypto/sha224.cpp
      src/crypto/sha512.cpp

--- a/include/fc/crypto/hash160.hpp
+++ b/include/fc/crypto/hash160.hpp
@@ -28,9 +28,6 @@
 #include <fc/reflect/typename.hpp>
 
 namespace fc{
-class sha512;
-class sha256;
-class ripemd160;
 
 class hash160
 {
@@ -112,12 +109,6 @@ namespace raw {
    void to_variant( const hash160& bi, variant& v, uint32_t max_depth );
    void from_variant( const variant& v, hash160& bi, uint32_t max_depth );
 
-   /*
-   typedef hash160 uint160_t;
-   typedef hash160 uint160;
-
-   template<> struct get_typename<uint160_t>    { static const char* name()  { return "uint160_t";  } };
-   */
   template<> struct get_typename<hash160>    { static const char* name()  { return "hash160";  } };
 } // namespace fc
 

--- a/include/fc/crypto/hash160.hpp
+++ b/include/fc/crypto/hash160.hpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2018 jmjatlanta and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+#include <boost/endian/buffers.hpp>
+#include <fc/fwd.hpp>
+#include <fc/io/raw_fwd.hpp>
+#include <fc/reflect/typename.hpp>
+
+namespace fc{
+class sha512;
+class sha256;
+class ripemd160;
+
+class hash160
+{
+   public:
+   hash160();
+   explicit hash160( const string& hex_str );
+
+   string str()const;
+   explicit operator string()const;
+
+   char* data() const;
+   size_t data_size() const { return 160/8; }
+
+   static hash160 hash( const char* d, uint32_t dlen );
+   static hash160 hash( const string& );
+
+   template<typename T>
+   static hash160 hash( const T& t ) 
+   { 
+      hash160::encoder e; 
+      fc::raw::pack(e,t);
+      return e.result(); 
+   } 
+
+   class encoder 
+   {
+      public:
+      encoder();
+      ~encoder();
+
+      void write( const char* d, uint32_t dlen );
+      void put( char c ) { write( &c, 1 ); }
+      void reset();
+      hash160 result();
+
+      private:
+      class impl;
+      fc::fwd<impl,96> my;
+      std::vector<uint8_t> bytes;
+   };
+
+   template<typename T>
+   inline friend T& operator<<( T& ds, const hash160& ep ) {
+      ds.write( ep.data(), sizeof(ep) );
+      return ds;
+   }
+
+   template<typename T>
+   inline friend T& operator>>( T& ds, hash160& ep ) {
+      ds.read( ep.data(), sizeof(ep) );
+      return ds;
+   }
+   friend hash160 operator << ( const hash160& h1, uint32_t i       );
+   friend bool operator == ( const hash160& h1, const hash160& h2 );
+   friend bool operator != ( const hash160& h1, const hash160& h2 );
+   friend hash160 operator ^  ( const hash160& h1, const hash160& h2 );
+   friend bool operator >= ( const hash160& h1, const hash160& h2 );
+   friend bool operator >  ( const hash160& h1, const hash160& h2 );
+   friend bool operator <  ( const hash160& h1, const hash160& h2 );
+
+   boost::endian::little_uint32_buf_t _hash[5];
+};
+
+namespace raw {
+
+   template<typename T>
+   inline void pack( T& ds, const hash160& ep, uint32_t _max_depth ) {
+      ds << ep;
+   }
+
+   template<typename T>
+   inline void unpack( T& ds, hash160& ep, uint32_t _max_depth ) {
+      ds >> ep;
+   }
+
+}
+
+   class variant;
+   void to_variant( const hash160& bi, variant& v, uint32_t max_depth );
+   void from_variant( const variant& v, hash160& bi, uint32_t max_depth );
+
+   /*
+   typedef hash160 uint160_t;
+   typedef hash160 uint160;
+
+   template<> struct get_typename<uint160_t>    { static const char* name()  { return "uint160_t";  } };
+   */
+  template<> struct get_typename<hash160>    { static const char* name()  { return "hash160";  } };
+} // namespace fc
+
+namespace std
+{
+   template<>
+   struct hash<fc::hash160>
+   {
+      size_t operator()( const fc::hash160& s )const
+      {
+         return  *((size_t*)&s);
+      }
+   };
+}

--- a/include/fc/crypto/sha1.hpp
+++ b/include/fc/crypto/sha1.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <boost/endian/buffers.hpp>
 #include <fc/fwd.hpp>
+#include <fc/io/raw_fwd.hpp>
 
 #include <functional>
 #include <string>
@@ -24,11 +25,11 @@ class sha1
 
     template<typename T>
     static sha1 hash( const T& t ) 
-    { 
+    {
       sha1::encoder e; 
-      e << t; 
+      raw::pack(e, t);
       return e.result(); 
-    } 
+    }
 
     class encoder 
     {

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -98,7 +98,8 @@ struct Derivation_reflection_transformer {
 
 /// Macro to transform reflected fields of a base class to a derived class and concatenate them to a type list
 #define FC_CONCAT_BASE_MEMBER_REFLECTIONS(r, derived, base) \
-   ::add_list<typelist::transform<reflector<base>::members, impl::Derivation_reflection_transformer<derived>>>
+   ::add_list<typelist::transform<reflector<base>::members, \
+                                  impl::Derivation_reflection_transformer<derived>::template transform>>
 /// Macro to concatenate a new @ref field_reflection to a typelist
 #define FC_CONCAT_MEMBER_REFLECTION(r, container, idx, member) \
    ::add<field_reflection<idx, container, decltype(container::member), &container::member>>

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -38,7 +38,7 @@ template<typename Class, std::size_t index> struct member_name {
  *  @tparam field A pointer-to-member for the reflected field
  */
 template<std::size_t Index, typename Container, typename Member, Member Container::*field>
-struct field_reflection {
+struct field_reflector {
    using container = Container;
    using type = Member;
    using reflector = fc::reflector<type>;
@@ -55,7 +55,7 @@ struct field_reflection {
 /// Basically the same as @ref field_reflection, but for inherited fields
 /// Note that inherited field reflections do not have an index field; indexes are for native fields only
 template<std::size_t IndexInBase, typename Base, typename Derived, typename Member, Member Base::*field>
-struct inherited_field_reflection {
+struct inherited_field_reflector {
    using container = Derived;
    using field_container = Base;
    using type = Member;
@@ -79,19 +79,193 @@ struct inherited_field_reflection {
    }
 };
 
+template<typename, typename, bool> struct basic_field_reflection;
+/**
+ * @brief An object reflection is a mirror-image of an object for which a reflector is defined.
+ * @tparam Object The type of the object this reflection mirrors
+ * @tparam Data A pointer to this type will be passed to the constructor of each FieldReflection to initialize it
+ * @tparam FieldReflection A template to instantiate for each field to make the reflections of the fields. The
+ * constructor will be passed a reference to the reflected field and a pointer to the Data object.
+ * @tparam Reflectors Used when the object_reflection is a field of another object_reflection, this holds the path of
+ * reflectors leading to the field this object_reflection reflects
+ *
+ * The object reflection has fields with names matching those of the reflected object. These fields are callable
+ * objects which return a type which can be treated like a reference to the field value. If the field's type is
+ * complex, an object_reflection of that field's object is returned.
+ *
+ * By default, the object_reflection is very simple and provides no additional functionality. The following two lines
+ * would be equivalent:
+ *
+ * \code{.cpp}
+ * my_object.int_field = 2;
+ * my_object_reflection.int_field() = 2;
+ * \endcode
+ *
+ * The real power lies in the fact that the field reflections are based on a template, meaning that the reflection
+ * can be instrumented by client code to do additional checking. For instance, a reflection template could be used
+ * which records which fields in the reflection were accessed, or which fields were written and what values that were
+ * read/written when.
+ *
+ * The default template is not instantiable, but provides example code for a reflection of the following type:
+ * \code{.cpp}
+ * struct Object {
+ *    int int_field;
+ *    const char char_field;
+ * };
+ * \endcode
+ *
+ * The object_reflection constructor takes a pointer to a Data object which will be distributed to all field
+ * reflections and subobject reflections. Memory for this pointer is managed by the client code, and the pointer is
+ * expected to remain valid for the lifetime of the object_reflection and all its children. The pointer is not used
+ * by the default basic_field_reflection types and may be null.
+ */
+template<typename Object, typename Data = void,
+         template<typename, typename, bool> class FieldReflection = basic_field_reflection,
+         typename Reflectors = typelist::list<>>
+struct object_reflection { constexpr static bool is_defined = false; Object& _ref_; Data* _data_; };
+
+/// Implementation of @ref basic_field_reflection -- has SFINAE template parameters
+// Default template: mutable unreflected types
+template<typename Reflectors, typename Data, bool is_const = false, typename = void>
+struct basic_field_reflection_impl {
+   using Field = typename typelist::last<Reflectors>::type;
+   Field& ref;
+   Data* data;
+
+   const Field& operator()() const { return ref; }
+   Field& operator()() { return ref; }
+   operator Field&() { return ref; }
+   operator const Field&() const { return ref; }
+};
+// Specialization for const unreflected types
+template<typename Reflectors, typename Data>
+struct basic_field_reflection_impl<Reflectors, Data, true, void> {
+   using Field = typename typelist::last<Reflectors>::type;
+   const Field& ref;
+   Data* data;
+
+   const Field& operator()() const { return ref; }
+   operator const Field&() const { return ref; }
+};
+// Specialization for mutable reflected types
+template<typename Reflectors, typename Data>
+struct basic_field_reflection_impl<Reflectors, Data, false,
+      std::enable_if_t<fc::object_reflection<typename typelist::last<Reflectors>::type>::is_defined>>
+{
+   using Field = typename typelist::last<Reflectors>::type;
+   Field& ref;
+   Data* data;
+
+   const object_reflection<Field> operator()() const { return object_reflection<Field, Reflectors>(ref); }
+   object_reflection<Field> operator()() { return object_reflection<Field, Reflectors>(ref); }
+   operator const Field&() const { return ref; }
+   operator Field&() { return ref; }
+};
+// Specialization for const reflected types
+template<typename Reflectors, typename Data>
+struct basic_field_reflection_impl<Reflectors, Data, true,
+      std::enable_if_t<fc::object_reflection<typename typelist::last<Reflectors>::type>::is_defined>>
+{
+   using Field = typename typelist::last<Reflectors>::type;
+   const Field& ref;
+   Data* data;
+
+   const object_reflection<Field> operator()() const { return object_reflection<const Field, Reflectors>(ref); }
+   operator const Field&() const { return ref; }
+};
+/**
+ * @brief A template for a basic field reflection that simply returns a reference to the reflected field
+ * @tparam Reflectors Stack of reflectors of the fields in the path to the reflected field
+ * @tparam Data Type of object to initialize the field reflection with
+ * @tparam is_const A boolean specifying whether the field is on a const object or not
+ *
+ * A field reflection is a mirror image of a field. Field reflections appear in object reflections, which are defined
+ * below. Field reflections are callable objects which have the same name as the field they reflect, and usually are
+ * intended to be treated as though they return a reference to that field.
+ *
+ * This class provides a basic field reflection type which provides no additional functionality, but simply allows
+ * reference access to the field
+ */
+template<typename Reflectors, typename Data = void, bool is_const = false>
+struct basic_field_reflection : basic_field_reflection_impl<Reflectors, Data, is_const> {
+   basic_field_reflection(typename basic_field_reflection::Field& ref, Data* data)
+      : basic_field_reflection_impl<Reflectors, Data, is_const>{ref, data} {}
+};
+template<typename Reflectors, typename Data>
+struct basic_field_reflection<Reflectors, Data, true> : basic_field_reflection_impl<Reflectors, Data, true> {
+   basic_field_reflection(const typename basic_field_reflection::Field& ref, Data* data)
+      : basic_field_reflection_impl<Reflectors, Data, true>{ref, data} {}
+};
+
+/// Macro to define a member reflection; intended to be used within BOOST_PP_SEQ_FOR_EACH_I
+#define FC_MEMBER_REFLECTION(R, X, IDX, MEMBER) IndexReflection<IDX> MEMBER;
+#define FC_INIT_MEMBER_REFLECTION(R, X, MEMBER) , MEMBER(_ref_.MEMBER, _data_)
+#define FC_OBJECT_REFLECTION_BASES(R, CONST, IDX, BASE) \
+   BOOST_PP_IF(IDX, BOOST_PP_COMMA, : BOOST_PP_EMPTY)() object_reflection<CONST BASE, Data, FR, Reflectors>
+#define FC_INIT_OBJECT_REFLECTION_BASE(R, CONST, BASE) object_reflection<CONST BASE, Data, FR, Reflectors>(ref, data),
+#define FC_OBJECT_REFLECTION_IMPL(TYPE, MEMBERS, BASES, CONST) \
+      constexpr static bool is_defined = true; \
+      TYPE& _ref_; \
+      Data* _data_; \
+      template<size_t index> \
+      using IndexReflection = \
+         FR<typelist::append<Reflectors, \
+                             typelist::at<typename reflector<std::decay_t<TYPE>>::native_members, index>>, \
+            Data, std::is_const<TYPE>::value>; \
+      BOOST_PP_SEQ_FOR_EACH_I(FC_MEMBER_REFLECTION, X, MEMBERS) \
+      object_reflection(TYPE& ref, Data* data = nullptr) \
+       : BOOST_PP_SEQ_FOR_EACH(FC_INIT_OBJECT_REFLECTION_BASE, CONST, BASES) _ref_(ref), _data_(data) \
+         BOOST_PP_SEQ_FOR_EACH(FC_INIT_MEMBER_REFLECTION, X, MEMBERS) {} \
+      operator const std::decay_t<TYPE>&() const { return _ref_; }
+/// Macro to define an @ref object_reflection for a supplied type
+#define FC_OBJECT_REFLECTION(TYPE, MEMBERS) \
+   namespace fc { \
+   template<typename Data, template<typename, typename, bool> class FR, typename Reflectors> \
+   struct object_reflection<TYPE, Data, FR, Reflectors> { \
+      FC_OBJECT_REFLECTION_IMPL(TYPE, MEMBERS, , ) \
+   }; \
+   template<typename Data, template<typename, typename, bool> class FR, typename Reflectors> \
+   struct object_reflection<const TYPE, Data, FR, Reflectors> { \
+      FC_OBJECT_REFLECTION_IMPL(const TYPE, MEMBERS, , const) \
+   }; }
+#define FC_OBJECT_REFLECTION_DERIVED(TYPE, INHERITS, MEMBERS) \
+   template<typename Data, template<typename, typename, bool> class FR, typename Reflectors> \
+   struct object_reflection<TYPE, Data, FR, Reflectors> \
+         BOOST_PP_SEQ_FOR_EACH_I(FC_OBJECT_REFLECTION_BASES, , INHERITS) { \
+      FC_OBJECT_REFLECTION_IMPL(TYPE, MEMBERS, INHERITS, ) \
+   }; \
+   template<typename Data, template<typename, typename, bool> class FR, typename Reflectors> \
+   struct object_reflection<const TYPE, Data, FR, Reflectors> \
+         BOOST_PP_SEQ_FOR_EACH_I(FC_OBJECT_REFLECTION_BASES, const, INHERITS) { \
+      FC_OBJECT_REFLECTION_IMPL(const TYPE, MEMBERS, INHERITS, const) \
+   };
+#define FC_OBJECT_REFLECTION_DERIVED_TEMPLATE(TEMPLATES, TYPE, INHERITS, MEMBERS) \
+   template<BOOST_PP_SEQ_ENUM(TEMPLATES), typename Data, \
+            template<typename, typename, bool> class FR, typename Reflectors> \
+   struct object_reflection<TYPE, Data, FR, Reflectors> \
+         BOOST_PP_SEQ_FOR_EACH_I(FC_OBJECT_REFLECTION_BASES, , INHERITS) { \
+      FC_OBJECT_REFLECTION_IMPL(TYPE, MEMBERS, INHERITS, ) \
+   }; \
+   template<BOOST_PP_SEQ_ENUM(TEMPLATES), typename Data, \
+            template<typename, typename, bool> class FR, typename Reflectors> \
+   struct object_reflection<const TYPE, Data, FR, Reflectors> \
+         BOOST_PP_SEQ_FOR_EACH_I(FC_OBJECT_REFLECTION_BASES, const, INHERITS) { \
+      FC_OBJECT_REFLECTION_IMPL(const TYPE, MEMBERS, INHERITS, const) \
+   };
+
 namespace impl {
 /// Template to make a transformer of a @ref field_reflection from a base class to a derived class
 template<typename Derived>
-struct Derivation_reflection_transformer {
+struct Derivation_reflector_transformer {
    template<typename> struct transform;
    template<std::size_t IndexInBase, typename BaseContainer, typename Member, Member BaseContainer::*field>
-   struct transform<field_reflection<IndexInBase, BaseContainer, Member, field>> {
-       using type = inherited_field_reflection<IndexInBase, BaseContainer, Derived, Member, field>;
+   struct transform<field_reflector<IndexInBase, BaseContainer, Member, field>> {
+       using type = inherited_field_reflector<IndexInBase, BaseContainer, Derived, Member, field>;
    };
    template<std::size_t IndexInBase, typename BaseContainer, typename IntermediateContainer,
             typename Member, Member BaseContainer::*field>
-   struct transform<inherited_field_reflection<IndexInBase, BaseContainer, IntermediateContainer, Member, field>> {
-       using type = inherited_field_reflection<IndexInBase, BaseContainer, Derived, Member, field>;
+   struct transform<inherited_field_reflector<IndexInBase, BaseContainer, IntermediateContainer, Member, field>> {
+       using type = inherited_field_reflector<IndexInBase, BaseContainer, Derived, Member, field>;
    };
 };
 } // namespace impl
@@ -99,10 +273,10 @@ struct Derivation_reflection_transformer {
 /// Macro to transform reflected fields of a base class to a derived class and concatenate them to a type list
 #define FC_CONCAT_BASE_MEMBER_REFLECTIONS(r, derived, base) \
    ::add_list<typelist::transform<reflector<base>::members, \
-                                  impl::Derivation_reflection_transformer<derived>::template transform>>
+                                  impl::Derivation_reflector_transformer<derived>::template transform>>
 /// Macro to concatenate a new @ref field_reflection to a typelist
 #define FC_CONCAT_MEMBER_REFLECTION(r, container, idx, member) \
-   ::add<field_reflection<idx, container, decltype(container::member), &container::member>>
+   ::add<field_reflector<idx, container, decltype(container::member), &container::member>>
 #define FC_REFLECT_MEMBER_NAME(r, container, idx, member) \
    template<> struct member_name<container, idx> { constexpr static const char* value = BOOST_PP_STRINGIZE(member); };
 #define FC_REFLECT_TEMPLATE_MEMBER_NAME(r, data, idx, member) \
@@ -124,11 +298,11 @@ template<typename T>
 struct reflector{
     typedef T type;
     typedef std::false_type is_defined;
-    /// A typelist with a @ref field_reflection for each native member (non-inherited) of the struct
+    /// A typelist with a @ref field_reflector for each native member (non-inherited) of the struct
     using native_members = typelist::list<>;
-    /// A typelist with a @ref field_reflection for each inherited member of the struct
+    /// A typelist with a @ref inherited_field_reflector for each inherited member of the struct
     using inherited_members = typelist::list<>;
-    /// A typelist with a @ref field_reflection for each member of the struct, starting with inherited members
+    /// A typelist with a {inherited_,}field_reflector for each member of the struct, starting with inherited members
     using members = typelist::list<>;
     /// A typelist of base classes for this type
     using base_classes = typelist::list<>;
@@ -307,6 +481,7 @@ template<> struct reflector<TYPE> {\
     }; \
     FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 }; \
+FC_OBJECT_REFLECTION_DERIVED( TYPE, INHERITS, MEMBERS ) \
 namespace member_names { \
 BOOST_PP_SEQ_FOR_EACH_I( FC_REFLECT_MEMBER_NAME, TYPE, MEMBERS ) \
 } }
@@ -334,6 +509,7 @@ template<BOOST_PP_SEQ_ENUM(TEMPLATE_ARGS)> struct reflector<TYPE> {\
     }; \
     FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 }; \
+FC_OBJECT_REFLECTION_DERIVED_TEMPLATE( TEMPLATE_ARGS, TYPE, INHERITS, MEMBERS) \
 namespace member_names { \
 BOOST_PP_SEQ_FOR_EACH_I( FC_REFLECT_TEMPLATE_MEMBER_NAME, (TEMPLATE_ARGS)(TYPE), MEMBERS ) \
 } }
@@ -358,7 +534,10 @@ template<> struct reflector<TYPE> {\
     }; \
     FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 }; \
-} // fc
+FC_OBJECT_REFLECTION_DERIVED( TYPE, INHERITS, MEMBERS) \
+namespace member_names { \
+BOOST_PP_SEQ_FOR_EACH_I( FC_REFLECT_MEMBER_NAME, TYPE, MEMBERS ) \
+} } // fc::member_names
 
 /**
  *  @def FC_REFLECT(TYPE,MEMBERS)
@@ -383,8 +562,8 @@ namespace fc { \
   template<> struct get_typename<TYPE>  { static const char* name()  { return BOOST_PP_STRINGIZE(TYPE);  } }; \
 }
 
-#define FC_INTERNAL_MEMBER_REFLECTION(r, container, idx, member) \
-   , BOOST_PP_SEQ_ENUM((fc::field_reflection<idx)(container)(decltype(container::member))(&container::member>))
+#define FC_INTERNAL_MEMBER_REFLECTOR(r, container, idx, member) \
+   , BOOST_PP_SEQ_ENUM((fc::field_reflector<idx)(container)(decltype(container::member))(&container::member>))
 
 /**
  *  @def FC_REFLECT_INTERNAL(TYPE,MEMBERS)
@@ -394,13 +573,15 @@ namespace fc { \
  *
  *  This macro may be used from within the public interface of a class to reflect its members. Note that to complete
  *  the reflection, FC_COMPLETE_INTERNAL_REFLECTION(TYPE) must still be invoked from the global namespace.
+ *
+ *  Unfortunately, it is not possible to autogenerate an @ref object_reflection for types with internal reflection
  */
 #define FC_REFLECT_INTERNAL( TYPE, MEMBERS ) \
-   struct FC_internal_reflection { \
+   struct FC_internal_reflector { \
       using type = TYPE; \
       /* FC_INTERNAL_MEMBER_REFLECTION always has a leading comma, so pre-pack the list with a void and slice it */ \
       using members = typename fc::typelist::slice<fc::typelist::list<void \
-         BOOST_PP_SEQ_FOR_EACH_I( FC_INTERNAL_MEMBER_REFLECTION, TYPE, MEMBERS ) >, 1>; \
+         BOOST_PP_SEQ_FOR_EACH_I( FC_INTERNAL_MEMBER_REFLECTOR, TYPE, MEMBERS ) >, 1>; \
       FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, BOOST_PP_SEQ_NIL, MEMBERS ) \
    };
 
@@ -416,7 +597,7 @@ namespace fc { \
    template<> struct reflector<TYPE> { \
       using type = TYPE; \
       using is_defined = std::true_type; \
-      using native_members = TYPE::FC_internal_reflection::members; \
+      using native_members = TYPE::FC_internal_reflector::members; \
       using inherited_members = typelist::list<>; \
       using members = native_members; \
       using base_classes = typelist::list<>; \
@@ -425,7 +606,7 @@ namespace fc { \
          total_member_count = local_member_count \
       }; \
       template<typename Visitor> \
-      static inline void visit(const Visitor& v) { TYPE::FC_internal_reflection::visit(v); } \
+      static inline void visit(const Visitor& v) { TYPE::FC_internal_reflector::visit(v); } \
    }; \
 }
 /**
@@ -440,7 +621,7 @@ namespace fc { \
    template<BOOST_PP_SEQ_ENUM(TEMPLATE_ARGS)> struct reflector<TYPE> { \
       using type = TYPE; \
       using is_defined = std::true_type; \
-      using native_members = typename TYPE::FC_internal_reflection::members; \
+      using native_members = typename TYPE::FC_internal_reflector::members; \
       using inherited_members = typelist::list<>; \
       using members = native_members; \
       using base_classes = typelist::list<>; \
@@ -449,6 +630,6 @@ namespace fc { \
          total_member_count = local_member_count \
       }; \
       template<typename Visitor> \
-      static inline void visit(const Visitor& v) { TYPE::FC_internal_reflection::visit(v); } \
+      static inline void visit(const Visitor& v) { TYPE::FC_internal_reflector::visit(v); } \
    }; \
 }

--- a/include/fc/reflect/typelist.hpp
+++ b/include/fc/reflect/typelist.hpp
@@ -48,10 +48,10 @@ struct make_sequence {
                                 list<std::integral_constant<std::size_t, count-1>>>::type;
 };
 
-template<typename, typename> struct transform;
-template<typename... List, typename Transformer>
+template<typename, template<typename> class> struct transform;
+template<typename... List, template<typename> class Transformer>
 struct transform<list<List...>, Transformer> {
-   using type = list<typename Transformer::template transform<List>::type...>;
+   using type = list<typename Transformer<List>::type...>;
 };
 
 template<typename Search, typename List> struct index_of;
@@ -166,7 +166,7 @@ struct builder {
 };
 
 /// Transform elements of a typelist
-template<typename List, typename Transformer>
+template<typename List, template<typename> class Transformer>
 using transform = typename impl::transform<List, Transformer>::type;
 
 /// Get the index of the given type within a list, or -1 if type is not found

--- a/include/fc/reflect/typelist.hpp
+++ b/include/fc/reflect/typelist.hpp
@@ -19,6 +19,19 @@ template<typename...> struct list;
 namespace impl {
 using typelist::list;
 
+template<typename, typename> struct append;
+template<typename... Ts, typename T> struct append<list<Ts...>, T> { using type = list<Ts..., T>; };
+
+template<typename, typename> struct prepend;
+template<typename... Ts, typename T> struct prepend<list<Ts...>, T> { using type = list<T, Ts...>; };
+
+template<typename, typename, typename, size_t, typename=void> struct insert;
+template<typename... Before, typename... After, typename New>
+struct insert<list<Before...>, list<After...>, New, 0, void> { using type = list<Before..., New, After...>; };
+template<typename... Before, typename T, typename... After, typename New, size_t position>
+struct insert<list<Before...>, list<T, After...>, New, position, std::enable_if_t<position != 0>>
+      : insert<list<Before..., T>, list<After...>, New, position-1> {};
+
 template<typename, template<typename...> class> struct apply;
 template<typename... Ts, template<typename...> class Delegate>
 struct apply<list<Ts...>, Delegate> { using type = Delegate<Ts...>; };
@@ -140,6 +153,18 @@ Ret dispatch_helper(Callable& c) { return c(T()); }
 /// The actual list type
 template<typename... Types>
 struct list { using type = list; };
+
+/// Append a new type to the end of a list
+template<typename List, typename NewType>
+using append = typename impl::append<List, NewType>::type;
+
+/// Prepend a new type to the end of a list
+template<typename List, typename NewType>
+using prepend = typename impl::prepend<List, NewType>::type;
+
+/// Insert a new type into the list at the given position
+template<typename List, typename NewType, size_t position>
+using insert = typename impl::insert<list<>, List, NewType, position>::type;
 
 /// Apply a list of types as arguments to another template
 template<typename List, template<typename...> class Delegate>

--- a/include/fc/reflect/typelist.hpp
+++ b/include/fc/reflect/typelist.hpp
@@ -23,6 +23,10 @@ template<typename, template<typename...> class> struct apply;
 template<typename... Ts, template<typename...> class Delegate>
 struct apply<list<Ts...>, Delegate> { using type = Delegate<Ts...>; };
 
+template<typename, template<typename...> class> struct apply_each;
+template<typename... Ts, template<typename...> class Delegate>
+struct apply_each<list<Ts...>, Delegate> { using type = list<Delegate<Ts>...>; };
+
 template<typename... Ts>
 struct length;
 template<> struct length<> { constexpr static std::size_t value = 0; };
@@ -117,7 +121,7 @@ template<typename... Results, typename T, typename... Types, std::size_t end>
 struct slice<list<Results...>, list<T, Types...>, 0, end, std::enable_if_t<end != 0>>
         : slice<list<Results..., T>, list<Types...>, 0, end-1> {};
 template<typename T, typename... Types, std::size_t start, std::size_t end>
-struct slice<list<>, list<T, Types...>, start, end, std::enable_if_t<start != 0>>
+struct slice<list<>, list<T, Types...>, start, end, std::enable_if_t<start != 0 && start != end>>
         : slice<list<>, list<Types...>, start-1, end-1> {};
 
 template<typename, typename> struct zip;
@@ -140,6 +144,10 @@ struct list { using type = list; };
 /// Apply a list of types as arguments to another template
 template<typename List, template<typename...> class Delegate>
 using apply = typename impl::apply<List, Delegate>::type;
+
+/// Apply each type in a list as the argument to another template
+template<typename List, template<typename...> class Delegate>
+using apply_each = typename impl::apply_each<List, Delegate>::type;
 
 /// Get the number of types in a list
 template<typename List>

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -314,6 +314,9 @@ public:
 
     template<typename T>
     bool is_type() const { return _tag == tag<T>::value; }
+
+    template<typename T>
+    static constexpr bool can_store() { return typelist::contains<list, T>(); }
 };
 template<> class static_variant<> {
 public:

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -247,27 +247,27 @@ public:
         }
     }
     template<typename visitor>
-    typename visitor::result_type visit(visitor& v) {
+    auto visit(visitor& v) {
         return visit( _tag, v, (void*) storage.data() );
     }
 
     template<typename visitor>
-    typename visitor::result_type visit(const visitor& v) {
+    auto visit(const visitor& v) {
         return visit( _tag, v, (void*) storage.data() );
     }
 
     template<typename visitor>
-    typename visitor::result_type visit(visitor& v)const {
+    auto visit(visitor& v)const {
         return visit( _tag, v, (const void*) storage.data() );
     }
 
     template<typename visitor>
-    typename visitor::result_type visit(const visitor& v)const {
+    auto visit(const visitor& v)const {
         return visit( _tag, v, (const void*) storage.data() );
     }
 
     template<typename visitor>
-    static typename visitor::result_type visit( tag_type tag, visitor& v, void* data )
+    static auto visit( tag_type tag, visitor& v, void* data )
     {
         FC_ASSERT( tag >= 0 && tag < count(), "Unsupported type ${tag}!", ("tag",tag) );
         return typelist::runtime::dispatch(list(), tag, [&v, data](auto t) {
@@ -276,7 +276,7 @@ public:
     }
 
     template<typename visitor>
-    static typename visitor::result_type visit( tag_type tag, const visitor& v, void* data )
+    static auto visit( tag_type tag, const visitor& v, void* data )
     {
         FC_ASSERT( tag >= 0 && tag < count(), "Unsupported type ${tag}!", ("tag",tag) );
         return typelist::runtime::dispatch(list(), tag, [&v, data](auto t) {
@@ -285,7 +285,7 @@ public:
     }
 
     template<typename visitor>
-    static typename visitor::result_type visit( tag_type tag, visitor& v, const void* data )
+    static auto visit( tag_type tag, visitor& v, const void* data )
     {
         FC_ASSERT( tag >= 0 && tag < count(), "Unsupported type ${tag}!", ("tag",tag) );
         return typelist::runtime::dispatch(list(), tag, [&v, data](auto t) {
@@ -294,7 +294,7 @@ public:
     }
 
     template<typename visitor>
-    static typename visitor::result_type visit( tag_type tag, const visitor& v, const void* data )
+    static auto visit( tag_type tag, const visitor& v, const void* data )
     {
         FC_ASSERT( tag >= 0 && tag < count(), "Unsupported type ${tag}!", ("tag",tag) );
         return typelist::runtime::dispatch(list(), tag, [&v, data](auto t) {

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -328,7 +328,6 @@ public:
     using tag_type = int64_t;
     static_variant() { FC_THROW_EXCEPTION(assert_exception, "Cannot create static_variant with no types"); }
 };
-template<typename... Types> class static_variant<typelist::list<Types...>> : public static_variant<Types...> {};
 
    struct from_static_variant 
    {

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -311,6 +311,11 @@ public:
     }
 
     tag_type which() const {return _tag;}
+    const char* content_typename() const {
+       return typelist::runtime::dispatch(list(), _tag, [](auto t) {
+          return get_typename<typename decltype(t)::type>::name();
+       });
+    }
 
     template<typename T>
     bool is_type() const { return _tag == tag<T>::value; }

--- a/src/crypto/hash160.cpp
+++ b/src/crypto/hash160.cpp
@@ -28,9 +28,6 @@
 #include <openssl/ripemd.h>
 #include <string.h>
 #include <fc/crypto/hash160.hpp>
-#include <fc/crypto/ripemd160.hpp>
-#include <fc/crypto/sha512.hpp>
-#include <fc/crypto/sha256.hpp>
 #include <fc/variant.hpp>
 #include <vector>
 #include "_digest_common.hpp"

--- a/src/crypto/hash160.cpp
+++ b/src/crypto/hash160.cpp
@@ -38,36 +38,33 @@ namespace fc
 hash160::hash160() { memset( _hash, 0, sizeof(_hash) ); }
 
 hash160::hash160( const string& hex_str ) {
-  fc::from_hex( hex_str, (char*)_hash, sizeof(_hash) );  
+   fc::from_hex( hex_str, (char*)_hash, sizeof(_hash) );  
 }
 
 string hash160::str()const {
-  return fc::to_hex( (char*)_hash, sizeof(_hash) );
+   return fc::to_hex( (char*)_hash, sizeof(_hash) );
 }
 
 hash160::operator string()const { return  str(); }
 
 char* hash160::data()const { return (char*)&_hash[0]; }
 
-
 class hash160::encoder::impl {
-public:
-   impl()
-   {
-   }
-
+   public:
+   impl() { }
 };
 
 hash160::encoder::~encoder() {}
 hash160::encoder::encoder() {}
 
 hash160 hash160::hash( const char* d, uint32_t dlen ) {
-  encoder e;
-  e.write(d,dlen);
-  return e.result();
+   encoder e;
+   e.write(d,dlen);
+   return e.result();
 }
+
 hash160 hash160::hash( const string& s ) {
-  return hash( s.c_str(), s.size() );
+   return hash( s.c_str(), s.size() );
 }
 
 void hash160::encoder::write( const char* d, uint32_t dlen )
@@ -93,45 +90,52 @@ hash160 hash160::encoder::result() {
 }
 
 hash160 operator << ( const hash160& h1, uint32_t i ) {
-  hash160 result;
-  fc::detail::shift_l( h1.data(), result.data(), result.data_size(), i );
-  return result;
+   hash160 result;
+   fc::detail::shift_l( h1.data(), result.data(), result.data_size(), i );
+   return result;
 }
+
 hash160 operator ^ ( const hash160& h1, const hash160& h2 ) {
-  hash160 result;
-  result._hash[0] = h1._hash[0].value() ^ h2._hash[0].value();
-  result._hash[1] = h1._hash[1].value() ^ h2._hash[1].value();
-  result._hash[2] = h1._hash[2].value() ^ h2._hash[2].value();
-  result._hash[3] = h1._hash[3].value() ^ h2._hash[3].value();
-  result._hash[4] = h1._hash[4].value() ^ h2._hash[4].value();
-  return result;
+   hash160 result;
+   result._hash[0] = h1._hash[0].value() ^ h2._hash[0].value();
+   result._hash[1] = h1._hash[1].value() ^ h2._hash[1].value();
+   result._hash[2] = h1._hash[2].value() ^ h2._hash[2].value();
+   result._hash[3] = h1._hash[3].value() ^ h2._hash[3].value();
+   result._hash[4] = h1._hash[4].value() ^ h2._hash[4].value();
+   return result;
 }
+
 bool operator >= ( const hash160& h1, const hash160& h2 ) {
-  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) >= 0;
+   return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) >= 0;
 }
+
 bool operator > ( const hash160& h1, const hash160& h2 ) {
-  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) > 0;
+   return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) > 0;
 }
+
 bool operator < ( const hash160& h1, const hash160& h2 ) {
-  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) < 0;
+   return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) < 0;
 }
+
 bool operator != ( const hash160& h1, const hash160& h2 ) {
-  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) != 0;
+   return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) != 0;
 }
+
 bool operator == ( const hash160& h1, const hash160& h2 ) {
-  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) == 0;
+   return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) == 0;
 }
   
-   void to_variant( const hash160& bi, variant& v, uint32_t max_depth )
-   {
-      to_variant( std::vector<char>( (const char*)&bi, ((const char*)&bi) + sizeof(bi) ), v, max_depth );
-   }
-   void from_variant( const variant& v, hash160& bi, uint32_t max_depth )
-   {
-      std::vector<char> ve = v.as< std::vector<char> >( max_depth );
-      memset( &bi, char(0), sizeof(bi) );
-      if( ve.size() )
-         memcpy( &bi, ve.data(), std::min<size_t>(ve.size(),sizeof(bi)) );
-  }
+void to_variant( const hash160& bi, variant& v, uint32_t max_depth )
+{
+   to_variant( std::vector<char>( (const char*)&bi, ((const char*)&bi) + sizeof(bi) ), v, max_depth );
+}
+
+void from_variant( const variant& v, hash160& bi, uint32_t max_depth )
+{
+   std::vector<char> ve = v.as< std::vector<char> >( max_depth );
+   memset( &bi, char(0), sizeof(bi) );
+   if( ve.size() )
+      memcpy( &bi, ve.data(), std::min<size_t>(ve.size(),sizeof(bi)) );
+}
   
 } // fc

--- a/src/crypto/hash160.cpp
+++ b/src/crypto/hash160.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2018 jmjatlanta and contributors.
+ *
+ * The MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <fc/crypto/hex.hpp>
+#include <fc/fwd_impl.hpp>
+#include <openssl/sha.h>
+#include <openssl/ripemd.h>
+#include <string.h>
+#include <fc/crypto/hash160.hpp>
+#include <fc/crypto/ripemd160.hpp>
+#include <fc/crypto/sha512.hpp>
+#include <fc/crypto/sha256.hpp>
+#include <fc/variant.hpp>
+#include <vector>
+#include "_digest_common.hpp"
+
+namespace fc 
+{
+  
+hash160::hash160() { memset( _hash, 0, sizeof(_hash) ); }
+
+hash160::hash160( const string& hex_str ) {
+  fc::from_hex( hex_str, (char*)_hash, sizeof(_hash) );  
+}
+
+string hash160::str()const {
+  return fc::to_hex( (char*)_hash, sizeof(_hash) );
+}
+
+hash160::operator string()const { return  str(); }
+
+char* hash160::data()const { return (char*)&_hash[0]; }
+
+
+class hash160::encoder::impl {
+public:
+   impl()
+   {
+   }
+
+};
+
+hash160::encoder::~encoder() {}
+hash160::encoder::encoder() {}
+
+hash160 hash160::hash( const char* d, uint32_t dlen ) {
+  encoder e;
+  e.write(d,dlen);
+  return e.result();
+}
+hash160 hash160::hash( const string& s ) {
+  return hash( s.c_str(), s.size() );
+}
+
+void hash160::encoder::write( const char* d, uint32_t dlen )
+{
+   for(uint32_t i = 0; i < dlen; ++i)
+      bytes.push_back(d[i]); 
+}
+
+hash160 hash160::encoder::result() {
+   // perform the first hashing function
+   SHA256_CTX sha_ctx;
+   SHA256_Init(&sha_ctx);
+   SHA256_Update( &sha_ctx, bytes.data(), bytes.size());
+   unsigned char sha_hash[SHA256_DIGEST_LENGTH];
+   SHA256_Final( sha_hash, &sha_ctx );
+   // perform the second hashing function
+   RIPEMD160_CTX ripe_ctx;
+   RIPEMD160_Init(&ripe_ctx);
+   RIPEMD160_Update( &ripe_ctx, sha_hash, SHA256_DIGEST_LENGTH );
+   hash160 h;
+   RIPEMD160_Final( (uint8_t *)h.data(), &ripe_ctx );
+   return h;
+}
+
+hash160 operator << ( const hash160& h1, uint32_t i ) {
+  hash160 result;
+  fc::detail::shift_l( h1.data(), result.data(), result.data_size(), i );
+  return result;
+}
+hash160 operator ^ ( const hash160& h1, const hash160& h2 ) {
+  hash160 result;
+  result._hash[0] = h1._hash[0].value() ^ h2._hash[0].value();
+  result._hash[1] = h1._hash[1].value() ^ h2._hash[1].value();
+  result._hash[2] = h1._hash[2].value() ^ h2._hash[2].value();
+  result._hash[3] = h1._hash[3].value() ^ h2._hash[3].value();
+  result._hash[4] = h1._hash[4].value() ^ h2._hash[4].value();
+  return result;
+}
+bool operator >= ( const hash160& h1, const hash160& h2 ) {
+  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) >= 0;
+}
+bool operator > ( const hash160& h1, const hash160& h2 ) {
+  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) > 0;
+}
+bool operator < ( const hash160& h1, const hash160& h2 ) {
+  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) < 0;
+}
+bool operator != ( const hash160& h1, const hash160& h2 ) {
+  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) != 0;
+}
+bool operator == ( const hash160& h1, const hash160& h2 ) {
+  return memcmp( h1._hash, h2._hash, sizeof(h1._hash) ) == 0;
+}
+  
+   void to_variant( const hash160& bi, variant& v, uint32_t max_depth )
+   {
+      to_variant( std::vector<char>( (const char*)&bi, ((const char*)&bi) + sizeof(bi) ), v, max_depth );
+   }
+   void from_variant( const variant& v, hash160& bi, uint32_t max_depth )
+   {
+      std::vector<char> ve = v.as< std::vector<char> >( max_depth );
+      memset( &bi, char(0), sizeof(bi) );
+      if( ve.size() )
+         memcpy( &bi, ve.data(), std::min<size_t>(ve.size(),sizeof(bi)) );
+  }
+  
+} // fc

--- a/tests/crypto/sha_tests.cpp
+++ b/tests/crypto/sha_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <fc/crypto/digest.hpp>
 #include <fc/crypto/ripemd160.hpp>
+#include <fc/crypto/hash160.hpp>
 #include <fc/crypto/sha1.hpp>
 #include <fc/crypto/sha224.hpp>
 #include <fc/crypto/sha256.hpp>
@@ -106,6 +107,18 @@ BOOST_AUTO_TEST_CASE(ripemd160_test)
     test<fc::ripemd160>( TEST5, "52783243c1697bdbe16d37f97f68f08325dc1528" );
     test_big<fc::ripemd160>( "29b6df855772aa9a95442bf83b282b495f9f6541" );
     test_stream<fc::ripemd160>();
+}
+
+BOOST_AUTO_TEST_CASE( hash160_test )
+{
+   
+   test<fc::hash160>( TEST1, "bb1be98c142444d7a56aa3981c3942a978e4dc33" );
+   test<fc::hash160>( TEST2, "b472a266d0bd89c13706a4132ccfb16f7c3b9fcb" );
+   test<fc::hash160>( TEST3, "69dda8a60e0cfc2353aa776864092c0e5ccb4834" );
+   test<fc::hash160>( TEST4, "dfcc6db6ea54d85d2e3a76573183f7a037a729b0" );
+   init_5();
+   test<fc::hash160>( TEST5, "f9be0e104ef2ed83a7ddb4765780951405e56ba4" ); 
+   test<fc::hash160>( TEST6, "3eca00d3b1fcafb0b74fa07fe890bea9b053a17e" );
 }
 
 BOOST_AUTO_TEST_CASE(sha1_test)

--- a/tests/reflection_tests.cpp
+++ b/tests/reflection_tests.cpp
@@ -49,60 +49,74 @@ BOOST_AUTO_TEST_SUITE( fc_reflection )
 BOOST_AUTO_TEST_CASE( reflection_static_tests )
 {
    // These are all compile-time tests, nothing actually happens here at runtime
+   using namespace fc::typelist;
    using base_reflection = fc::reflector<reflect_test_base>;
    using derived_reflection = fc::reflector<reflect_test_derived>;
-   static_assert(fc::typelist::length<base_reflection::members>() == 2, "");
-   static_assert(fc::typelist::length<derived_reflection::members>() == 3, "");
-   static_assert(fc::typelist::at<derived_reflection::members, 0>::is_derived, "");
-   static_assert(std::is_same<fc::typelist::at<derived_reflection::members, 0>::field_container,
-                              reflect_test_base>::value, "");
-   static_assert(fc::typelist::at<derived_reflection::members, 1>::is_derived, "");
-   static_assert(std::is_same<fc::typelist::at<derived_reflection::members, 1>::field_container,
-                              reflect_test_base>::value, "");
-   static_assert(fc::typelist::at<derived_reflection::members, 2>::is_derived == false, "");
-   static_assert(std::is_same<fc::typelist::slice<fc::typelist::list<int, bool, char>, 0, 1>,
-                              fc::typelist::list<int>>::value, "");
-   static_assert(std::is_same<fc::typelist::slice<fc::typelist::list<int, bool, char>, 0, 2>,
-                              fc::typelist::list<int, bool>>::value, "");
-   static_assert(std::is_same<fc::typelist::slice<fc::typelist::list<int, bool, char>, 0, 3>,
-                              fc::typelist::list<int, bool, char>>::value, "");
-   static_assert(std::is_same<fc::typelist::slice<fc::typelist::list<int, bool, char>, 1, 3>,
-                              fc::typelist::list<bool, char>>::value, "");
-   static_assert(std::is_same<fc::typelist::slice<fc::typelist::list<int, bool, char>, 2, 3>,
-                              fc::typelist::list<char>>::value, "");
-   static_assert(std::is_same<fc::typelist::slice<fc::typelist::list<int, bool, char>, 1, 2>,
-                              fc::typelist::list<bool>>::value, "");
-   static_assert(std::is_same<fc::typelist::slice<fc::typelist::list<int, bool, char>, 1>,
-                              fc::typelist::list<bool, char>>::value, "");
-   static_assert(std::is_same<fc::typelist::make_sequence<0>, fc::typelist::list<>>::value, "");
-   static_assert(std::is_same<fc::typelist::make_sequence<1>,
-                              fc::typelist::list<std::integral_constant<size_t, 0>>>::value, "");
-   static_assert(std::is_same<fc::typelist::make_sequence<2>,
-                              fc::typelist::list<std::integral_constant<size_t, 0>,
-                                                 std::integral_constant<size_t, 1>>>::value, "");
-   static_assert(std::is_same<fc::typelist::make_sequence<3>,
-                              fc::typelist::list<std::integral_constant<size_t, 0>,
-                                                 std::integral_constant<size_t, 1>,
-                                                 std::integral_constant<size_t, 2>>>::value, "");
-   static_assert(std::is_same<fc::typelist::zip<fc::typelist::list<>, fc::typelist::list<>>,
-                              fc::typelist::list<>>::value, "");
-   static_assert(std::is_same<fc::typelist::zip<fc::typelist::list<bool>, fc::typelist::list<char>>,
-                              fc::typelist::list<fc::typelist::list<bool, char>>>::value, "");
-   static_assert(std::is_same<fc::typelist::zip<fc::typelist::list<int, bool>, fc::typelist::list<char, double>>,
-                              fc::typelist::list<fc::typelist::list<int, char>,
-                                                 fc::typelist::list<bool, double>>>::value, "");
-   static_assert(std::is_same<fc::typelist::index<fc::typelist::list<>>, fc::typelist::list<>>::value, "");
-   static_assert(std::is_same<fc::typelist::index<fc::typelist::list<int, bool, char, double>>,
-                              fc::typelist::list<fc::typelist::list<std::integral_constant<size_t, 0>, int>,
-                                                 fc::typelist::list<std::integral_constant<size_t, 1>, bool>,
-                                                 fc::typelist::list<std::integral_constant<size_t, 2>, char>,
-                                                 fc::typelist::list<std::integral_constant<size_t, 3>, double>>
-                 >::value, "");
-   static_assert(fc::typelist::length<fc::reflector<reflect_test_internal>::members>() == 2, "");
-   static_assert(std::is_same<fc::typelist::at<fc::reflector<reflect_test_internal>::members, 0>::type, int>{}, "");
-   static_assert(std::is_same<fc::typelist::at<fc::reflector<reflect_test_internal>::members, 1>::type, char>{}, "");
-   static_assert(fc::typelist::length<fc::reflector<reflect_internal_sfinae<bool>>::members>() == 1, "");
-   static_assert(fc::typelist::length<fc::reflector<reflect_internal_sfinae<char>>::members>() == 2, "");
+   static_assert(length<base_reflection::members>() == 2, "");
+   static_assert(length<derived_reflection::members>() == 3, "");
+   static_assert(at<derived_reflection::members, 0>::is_derived, "");
+   static_assert(std::is_same<at<derived_reflection::members, 0>::field_container, reflect_test_base>::value, "");
+   static_assert(at<derived_reflection::members, 1>::is_derived, "");
+   static_assert(std::is_same<at<derived_reflection::members, 1>::field_container, reflect_test_base>::value, "");
+   static_assert(at<derived_reflection::members, 2>::is_derived == false, "");
+   static_assert(std::is_same<slice<list<int, bool, char>, 0, 1>, list<int>>::value, "");
+   static_assert(std::is_same<slice<list<int, bool, char>, 0, 2>, list<int, bool>>::value, "");
+   static_assert(std::is_same<slice<list<int, bool, char>, 0, 3>, list<int, bool, char>>::value, "");
+   static_assert(std::is_same<slice<list<int, bool, char>, 1, 3>, list<bool, char>>::value, "");
+   static_assert(std::is_same<slice<list<int, bool, char>, 2, 3>, list<char>>::value, "");
+   static_assert(std::is_same<slice<list<int, bool, char>, 1, 2>, list<bool>>::value, "");
+   static_assert(std::is_same<slice<list<int, bool, char>, 1>, list<bool, char>>::value, "");
+   static_assert(std::is_same<make_sequence<0>, list<>>::value, "");
+   static_assert(std::is_same<make_sequence<1>, list<std::integral_constant<size_t, 0>>>::value, "");
+   static_assert(std::is_same<make_sequence<2>,
+                              list<std::integral_constant<size_t, 0>, std::integral_constant<size_t, 1>>>::value, "");
+   static_assert(std::is_same<make_sequence<3>, list<std::integral_constant<size_t, 0>,
+                                                     std::integral_constant<size_t, 1>,
+                                                     std::integral_constant<size_t, 2>>>::value, "");
+   static_assert(std::is_same<zip<list<>, list<>>, list<>>::value, "");
+   static_assert(std::is_same<zip<list<bool>, list<char>>, list<list<bool, char>>>::value, "");
+   static_assert(std::is_same<zip<list<int, bool>,
+                              list<char, double>>, list<list<int, char>, list<bool, double>>>::value, "");
+   static_assert(std::is_same<fc::typelist::index<list<>>, list<>>::value, "");
+   static_assert(std::is_same<fc::typelist::index<list<int, bool, char, double>>,
+                              list<list<std::integral_constant<size_t, 0>, int>,
+                                   list<std::integral_constant<size_t, 1>, bool>,
+                                   list<std::integral_constant<size_t, 2>, char>,
+                                   list<std::integral_constant<size_t, 3>, double>>>::value, "");
+   static_assert(length<fc::reflector<reflect_test_internal>::members>() == 2, "");
+   static_assert(std::is_same<at<fc::reflector<reflect_test_internal>::members, 0>::type, int>{}, "");
+   static_assert(std::is_same<at<fc::reflector<reflect_test_internal>::members, 1>::type, char>{}, "");
+   static_assert(length<fc::reflector<reflect_internal_sfinae<bool>>::members>() == 1, "");
+   static_assert(length<fc::reflector<reflect_internal_sfinae<char>>::members>() == 2, "");
+   static_assert(std::is_same<prepend<list<>, bool>, list<bool>>{}, "");
+   static_assert(std::is_same<prepend<list<int>, bool>, list<bool, int>>{}, "");
+   static_assert(std::is_same<prepend<list<int, char>, bool>, list<bool, int, char>>{}, "");
+   static_assert(std::is_same<append<list<>, bool>, list<bool>>{}, "");
+   static_assert(std::is_same<append<list<int>, bool>, list<int, bool>>{}, "");
+   static_assert(std::is_same<append<list<int, char>, bool>, list<int, char, bool>>{}, "");
+   static_assert(std::is_same<insert<list<>, bool, 0>, list<bool>>{}, "");
+   static_assert(std::is_same<insert<list<char>, bool, 0>, list<bool, char>>{}, "");
+   static_assert(std::is_same<insert<list<char>, bool, 1>, list<char, bool>>{}, "");
+   static_assert(std::is_same<insert<list<int, char>, bool, 0>, list<bool, int, char>>{}, "");
+   static_assert(std::is_same<insert<list<int, char>, bool, 1>, list<int, bool, char>>{}, "");
+   static_assert(std::is_same<insert<list<int, char>, bool, 2>, list<int, char, bool>>{}, "");
+}
+
+BOOST_AUTO_TEST_CASE( object_reflection_tests )
+{
+   reflect_test_derived obj;
+   fc::object_reflection<reflect_test_derived> reflection(obj);
+   BOOST_CHECK_EQUAL(obj.x, reflection.x());
+   BOOST_CHECK_EQUAL(obj.y, reflection.y());
+   BOOST_CHECK_EQUAL(obj.z, reflection.z());
+   reflection.x() = 77;
+   reflection.z() = 1;
+   BOOST_CHECK_EQUAL(obj.x, 77);
+   BOOST_CHECK_EQUAL(obj.z, 1);
+   fc::object_reflection<const reflect_test_derived> const_reflection(obj);
+   BOOST_CHECK_EQUAL(obj.x, const_reflection.x());
+   BOOST_CHECK_EQUAL(obj.y, const_reflection.y());
+   BOOST_CHECK_EQUAL(obj.z, const_reflection.z());
 }
 
 BOOST_AUTO_TEST_CASE( typelist_dispatch_test )


### PR DESCRIPTION
These are the updates I've made to FC to support Tanks and Taps. There's some interesting stuff in here:

 - John's `hash160`
 - Updates to `static_variant`
 - Updates to my `typelist`
 - New `object_reflection` to create instrumented pseudo-references to reflected types (see e1ed222)