### PR TITLE
Update to_variant(size_t) for macOS and OpenBSD

### DIFF
--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -581,9 +581,7 @@ namespace fc
       memset( this, 0, sizeof(*this) );
       to_variant( val, *this, max_depth );
    }
-   #ifdef __APPLE__
-   inline void to_variant( size_t s, variant& v, uint32_t max_depth ) { v = variant(uint64_t(s)); }
-   #endif
+
    template<typename T>
    void to_variant( const std::shared_ptr<T>& var, variant& vo, uint32_t max_depth )
    {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -701,9 +701,8 @@ void from_variant( const variant& var, uint128_t& vo, uint32_t max_depth )
 #endif
 }
 
-#if defined(__APPLE__)
-#elif defined(__OpenBSD__)
-   void to_variant( size_t s, variant& v, uint32_t max_depth ) { v = variant( int64_t(s) ); }
+#if defined(__APPLE__) or defined(__OpenBSD__)
+   void to_variant( size_t s, variant& v, uint32_t max_depth ) { v = variant( uint64_t(s) ); }
 #elif !defined(_WIN32)
    void to_variant( long long int s, variant& v, uint32_t max_depth ) { v = variant( int64_t(s) ); }
    void to_variant( unsigned long long int s, variant& v, uint32_t max_depth ) { v = variant( uint64_t(s)); }


### PR DESCRIPTION
Fix to_variant(size_t) for OpenBSD, move implementation for macOS to cpp file.

Related to https://github.com/bitshares/bitshares-fc/pull/148#pullrequestreview-383330347.