### PR TITLE
Fix race condition in websocket server close

### DIFF
--- a/src/network/http/websocket.cpp
+++ b/src/network/http/websocket.cpp
@@ -665,8 +665,9 @@ namespace fc { namespace http {
 
    void websocket_server::close()
    {
+      auto cpy_con = my->_connections;
       websocketpp::lib::error_code ec;
-      for( auto& connection : my->_connections )
+      for( auto& connection : cpy_con )
          my->_server.close( connection.first, websocketpp::close::status::normal, "Goodbye", ec );
    }
 
@@ -709,8 +710,9 @@ namespace fc { namespace http {
 
    void websocket_tls_server::close()
    {
+      auto cpy_con = my->_connections;
       websocketpp::lib::error_code ec;
-      for( auto& connection : my->_connections )
+      for( auto& connection : cpy_con )
          my->_server.close( connection.first, websocketpp::close::status::normal, "Goodbye", ec );
    }
 


### PR DESCRIPTION
Note: the close() functions are not yet used in bitshares-core, but only in tests in FC.
The new code is not fully thread-safe either.