### PR TITLE
Fix Github Autobuild for macOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -131,7 +131,7 @@ jobs:
         brew install autoconf automake libtool
         brew install ccache
         brew search boost
-        brew install boost@1.60
+        brew install bitshares/boost160/boost@1.60
     - uses: actions/checkout@v2
       with:
         submodules: recursive


### PR DESCRIPTION
As a temporary solution, install boost 1.60 from our own tap.

The same code change as https://github.com/bitshares/bitshares-core/pull/2254 for https://github.com/bitshares/bitshares-core/issues/2253.