### PR TITLE
Fix parallel-tests script for cli_test in bitshares-core

### DIFF
--- a/tests/run-parallel-tests.sh
+++ b/tests/run-parallel-tests.sh
@@ -23,7 +23,7 @@ else
     | while read t; do
 	case "$t" in
 	/*) echo "$pre$t"; ;;
-	*) pre="$t"; ;;
+	*) echo "$t"; ;;
 	esac
       done \
     | parallel echo Running {}\; "$@" -t {}


### PR DESCRIPTION
The cli_test test cases are effectively skipped when parallelization is possible due to a bug in the script. This PR fixes it. The related issue in bitshares-core is https://github.com/bitshares/bitshares-core/issues/2274.