### PR TITLE
fix for static initialization order segfault

### DIFF
--- a/src/crypto/openssl.cpp
+++ b/src/crypto/openssl.cpp
@@ -12,17 +12,21 @@ namespace  fc
 {
     struct openssl_scope
     {
-       static path _configurationFilePath;
+       static path & _configurationFilePath()
+       {
+          static path orderindependentstorage;
+          return orderindependentstorage;
+       }
        openssl_scope()
        {
           ERR_load_crypto_strings(); 
           OpenSSL_add_all_algorithms();
 
-          const boost::filesystem::path& boostPath = _configurationFilePath;
+          const boost::filesystem::path& boostPath = _configurationFilePath();
           if(boostPath.empty() == false)
           {
             std::string varSetting("OPENSSL_CONF=");
-            varSetting += _configurationFilePath.to_native_ansi_path();
+            varSetting += _configurationFilePath().to_native_ansi_path();
 #if defined(WIN32)
             _putenv((char*)varSetting.c_str());
 #else
@@ -51,11 +55,9 @@ namespace  fc
        }
     };
 
-    path openssl_scope::_configurationFilePath;
-
     void store_configuration_path(const path& filePath)
     {
-      openssl_scope::_configurationFilePath = filePath;
+      openssl_scope::_configurationFilePath() = filePath;
     }
    
     int init_openssl()


### PR DESCRIPTION
It looks like https://github.com/bitshares/bitshares-core/issues/2276 was caused by static initialization order.

This puts the static member in a static function so it is initialized on first use.  There are probably other solutions, too, if this one is undesired.  This fixes my crash.