### PR TITLE
Update README to use the Travis-CI.com badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 fc
 ==
 
-[![](https://travis-ci.org/bitshares/bitshares-fc.svg?branch=master)](https://travis-ci.org/bitshares/bitshares-fc) 
+[![](https://travis-ci.com/bitshares/bitshares-fc.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-fc) 
 [![](https://github.com/bitshares/bitshares-fc/workflows/Github%20Autobuild/badge.svg?branch=master)](https://github.com/bitshares/bitshares-fc/actions?query=branch%3Amaster)
 
 **NOTE:** This fork reverts upstream commit a421e280488385cab26a42153f7ce3c8d5b6281f to avoid changing the BitShares API.


### PR DESCRIPTION
The migration has been done except the badges.

Partial job for https://github.com/bitshares/bitshares-core/issues/2312.