### PR TITLE
Stop using Travis-CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 fc
 ==
 
-[![](https://travis-ci.com/bitshares/bitshares-fc.svg?branch=master)](https://travis-ci.com/bitshares/bitshares-fc) 
 [![](https://github.com/bitshares/bitshares-fc/workflows/Github%20Autobuild/badge.svg?branch=master)](https://github.com/bitshares/bitshares-fc/actions?query=branch%3Amaster)
 
 **NOTE:** This fork reverts upstream commit a421e280488385cab26a42153f7ce3c8d5b6281f to avoid changing the BitShares API.


### PR DESCRIPTION
For https://github.com/bitshares/bitshares-core/issues/2312.

* The `.travis.yml` file will be kept for reference so far and will be removed in the future.
* There is a webhook in project settings, disabled (but did not delete).