### PR TITLE
Support macOS 11 Big Sur in Github CI

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -6,8 +6,14 @@ env:
 jobs:
   test-macos:
     name: Build and run tests in macOS
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11.0]
+    runs-on: ${{ matrix.os }}
     steps:
+    - name: Use XCode 12.2 for Big Sur
+      if: contains(matrix.os, 'macos-11.0')
+      run: sudo xcode-select -s "/Applications/Xcode_12.2.app"
     - name: Install dependencies
       run: |
         brew install autoconf automake libtool

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -50,3 +50,5 @@ vendor/editline is copyright Simmule Turner and Rich Salz and covered by a BSD-l
 vendor/secp256k1-zkp is copyright Pieter Wuille and covered by the MIT/X11 license. See vendor/secp256k1-zkp/COPYING.
 
 vendor/websocketpp is copyright Peter Thorson and covered by a 3-clause BSD-license. It also includes code from 4th-party authors with various copyrights, see vendor/websocketpp/COPYING.
+
+.github/workflows/build-and-test-macos.yml: the code in the step "Use XCode 12.2 for Big Sur" was taken from https://github.com/d12frosted/homebrew-emacs-plus/commit/315f55c7a36ba13e533a8a9bb7111b489398e86a , under the MIT License, Copyright (c) 2016-2020 Boris Buliga. See licenses/LICENSE-MIT.d12frosted.txt .

--- a/licenses/LICENSE-MIT.d12frosted.txt
+++ b/licenses/LICENSE-MIT.d12frosted.txt
@@ -1,0 +1,25 @@
+Some code in commit 55fb37d858d6f8a51bf75ff21f4e153ca31c36d7 was got from
+https://github.com/d12frosted/homebrew-emacs-plus/commit/315f55c7a36ba13e533a8a9bb7111b489398e86a
+which was licensed under the MIT License:
+
+MIT License
+
+Copyright (c) 2016-2020 Boris Buliga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The code in the step "Use XCode 12.2 for Big Sur" is from https://github.com/d12frosted/homebrew-emacs-plus/commit/315f55c7a36ba13e533a8a9bb7111b489398e86a , under the MIT License, Copyright (c) 2016-2020 Boris Buliga.