### PR TITLE
Fix assigning instead of comparing

### DIFF
--- a/src/log/console_appender.cpp
+++ b/src/log/console_appender.cpp
@@ -49,9 +49,9 @@ namespace fc {
 #endif
       my->cfg = console_appender_config;
 #ifdef WIN32
-         if (my->cfg.stream = stream::std_error)
+         if (my->cfg.stream == stream::std_error)
            my->console_handle = GetStdHandle(STD_ERROR_HANDLE);
-         else if (my->cfg.stream = stream::std_out)
+         else if (my->cfg.stream == stream::std_out)
            my->console_handle = GetStdHandle(STD_OUTPUT_HANDLE);
 #endif
 


### PR DESCRIPTION
The old code uses an operator for assignment when the intention was to perform a comparison.