### PR TITLE
add sizeof checks to impl declaration in tcp_socket.hpp for compatibility

### DIFF
--- a/include/fc/network/tcp_socket.hpp
+++ b/include/fc/network/tcp_socket.hpp
@@ -61,7 +61,7 @@ namespace fc {
         sizeof(fc::future<size_t>) +
         sizeof(boost::asio::ip::tcp::socket) +
         sizeof(tcp_socket_io_hooks*)
-    > my;
+      > my;
 
   };
   typedef std::shared_ptr<tcp_socket> tcp_socket_ptr;

--- a/include/fc/network/tcp_socket.hpp
+++ b/include/fc/network/tcp_socket.hpp
@@ -55,7 +55,14 @@ namespace fc {
     private:
       friend class tcp_server;
       class impl;
-      fc::fwd<impl,sizeof(void* /*vtable*/)+sizeof(fc::future<size_t>)*2+sizeof(boost::asio::ip::tcp::socket)+sizeof(tcp_socket_io_hooks*)> my;
+      fc::fwd<impl,
+        sizeof(void* /*vtable*/) +
+        sizeof(fc::future<size_t>) +
+        sizeof(fc::future<size_t>) +
+        sizeof(boost::asio::ip::tcp::socket) +
+        sizeof(tcp_socket_io_hooks*)
+    > my;
+
   };
   typedef std::shared_ptr<tcp_socket> tcp_socket_ptr;
 

--- a/include/fc/network/tcp_socket.hpp
+++ b/include/fc/network/tcp_socket.hpp
@@ -3,6 +3,9 @@
 #include <fc/io/iostream.hpp>
 #include <fc/time.hpp>
 
+#include <fc/asio.hpp>
+#include <fc/thread/future.hpp>
+
 namespace fc {
   namespace ip { class endpoint; }
 
@@ -52,11 +55,7 @@ namespace fc {
     private:
       friend class tcp_server;
       class impl;
-      #ifdef _WIN64
-      fc::fwd<impl,0xa8> my;
-      #else
-      fc::fwd<impl,0x60> my;
-      #endif
+      fc::fwd<impl,sizeof(void* /*vtable*/)+sizeof(fc::future<size_t>)*2+sizeof(boost::asio::ip::tcp::socket)+sizeof(tcp_socket_io_hooks*)> my;
   };
   typedef std::shared_ptr<tcp_socket> tcp_socket_ptr;
 


### PR DESCRIPTION
this is only one class, but shows the idea

personally i think it would be more maintainable and clearer to put the entire class declaration in the header file, but that's a bigger change

re https://github.com/bitshares/bitshares-fc/pull/231#issuecomment-766455020