### PR TITLE
Fix cache for matrix in Github Actions

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -33,13 +33,13 @@ jobs:
               ..
         popd
     - name: Load Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ccache
-        key: ccache-osx-${{ github.ref }}-${{ github.sha }}
+        key: ccache-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ccache-osx-${{ github.ref }}-
-          ccache-osx-
+          ccache-${{ matrix.os }}-${{ github.ref }}-
+          ccache-${{ matrix.os }}-
     - name: Build
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"

--- a/.github/workflows/build-and-test-ubuntu-debug.yml
+++ b/.github/workflows/build-and-test-ubuntu-debug.yml
@@ -32,7 +32,7 @@ jobs:
                      libboost-context-dev \
                      libboost-regex-dev \
                      libboost-coroutine-dev
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Configure
@@ -49,14 +49,13 @@ jobs:
               ..
         popd
     - name: Load Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ccache
-        key: ccache-debug-${{ github.ref }}-${{ github.sha }}
+        key: ccache-debug-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ccache-debug-${{ github.ref }}-
-          ccache-debug-
-          ccache-
+          ccache-debug-${{ matrix.os }}-${{ github.ref }}-
+          ccache-debug-${{ matrix.os }}-
     - name: Build
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"

--- a/.github/workflows/build-and-test-ubuntu-release.yml
+++ b/.github/workflows/build-and-test-ubuntu-release.yml
@@ -32,7 +32,7 @@ jobs:
                      libboost-context-dev \
                      libboost-regex-dev \
                      libboost-coroutine-dev
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Configure
@@ -52,11 +52,10 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ccache
-        key: ccache-release-${{ github.ref }}-${{ github.sha }}
+        key: ccache-release-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
-          ccache-release-${{ github.ref }}-
-          ccache-release-
-          ccache-
+          ccache-release-${{ matrix.os }}-${{ github.ref }}-
+          ccache-release-${{ matrix.os }}-
     - name: Build
       run: |
         export CCACHE_DIR="$GITHUB_WORKSPACE/ccache"


### PR DESCRIPTION
Each build environment should have its own cache. This PR does it.

See also: https://github.com/bitshares/bitshares-core/pull/2366.