### PR TITLE
Improve safe<T>

### DIFF
--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -18,7 +18,7 @@ jobs:
         brew install parallel
         brew search boost
         brew install bitshares/boost/boost@1.69
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Configure
@@ -33,7 +33,7 @@ jobs:
               ..
         popd
     - name: Load Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ccache
         key: ccache-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/build-and-test-macos.yml
+++ b/.github/workflows/build-and-test-macos.yml
@@ -29,7 +29,7 @@ jobs:
               -D CMAKE_C_COMPILER_LAUNCHER=ccache \
               -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -D BOOST_ROOT=/usr/local/opt/boost@1.69 \
-              -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl \
+              -D OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 \
               ..
         popd
     - name: Load Cache

--- a/.github/workflows/build-and-test-ubuntu-debug.yml
+++ b/.github/workflows/build-and-test-ubuntu-debug.yml
@@ -32,7 +32,7 @@ jobs:
                      libboost-context-dev \
                      libboost-regex-dev \
                      libboost-coroutine-dev
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Configure
@@ -49,7 +49,7 @@ jobs:
               ..
         popd
     - name: Load Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ccache
         key: ccache-debug-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/build-and-test-ubuntu-debug.yml
+++ b/.github/workflows/build-and-test-ubuntu-debug.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build and run tests in Debug mode
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install dependencies

--- a/.github/workflows/build-and-test-ubuntu-release.yml
+++ b/.github/workflows/build-and-test-ubuntu-release.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build and run tests in Release mode
     strategy:
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04 ]
+        os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install dependencies

--- a/.github/workflows/build-and-test-ubuntu-release.yml
+++ b/.github/workflows/build-and-test-ubuntu-release.yml
@@ -32,7 +32,7 @@ jobs:
                      libboost-context-dev \
                      libboost-regex-dev \
                      libboost-coroutine-dev
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Configure
@@ -49,7 +49,7 @@ jobs:
               ..
         popd
     - name: Load Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ccache
         key: ccache-release-${{ matrix.os }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -8,7 +8,7 @@ jobs:
     name: Scan with SonarScanner
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Download and install latest SonarScanner CLI tool

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -38,6 +38,7 @@ jobs:
           sudo apt-get install -y --allow-downgrades openssl=${openssl_ver} libssl-dev=${libssl_ver}
         sudo apt-get install -y \
                      ccache \
+                     gcovr \
                      parallel \
                      libboost-thread-dev \
                      libboost-iostreams-dev \
@@ -98,8 +99,6 @@ jobs:
         _EOT_
     - name: Prepare for scanning with SonarScanner
       run: |
-        find _build/CMakeFiles/fc.dir -type d -print \
-          | while read d; do gcov -o "$d" "${d/_build*.dir/.}"/*.cpp; done >/dev/null
         if [ -z "$GITHUB_HEAD_REF" ]; then \
           if [ "$GITHUB_REF" != "refs/heads/master" ]; then \
             echo "sonar.branch.target=master" >> sonar-project.properties; \
@@ -112,6 +111,10 @@ jobs:
             echo "sonar.branch.name=${GITHUB_REF}" >> sonar-project.properties; \
           fi \
         fi
+        pushd _build
+        gcovr --version
+        gcovr --exclude-unreachable-branches --sonarqube ../coverage.xml -r ..
+        popd
     - name: Scan with SonarScanner
       env:
         # to get access to secrets.SONAR_TOKEN, provide GITHUB_TOKEN

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -78,7 +78,6 @@ jobs:
       with:
         path: |
           ccache
-          sonar_cache
         key: sonar-${{ env.OS_VERSION }}-${{ github.ref }}-${{ github.sha }}
         restore-keys: |
           sonar-${{ env.OS_VERSION }}-${{ github.ref }}-
@@ -99,7 +98,6 @@ jobs:
         _EOT_
     - name: Prepare for scanning with SonarScanner
       run: |
-        mkdir -p sonar_cache
         find _build/CMakeFiles/fc.dir -type d -print \
           | while read d; do gcov -o "$d" "${d/_build*.dir/.}"/*.cpp; done >/dev/null
         if [ -z "$GITHUB_HEAD_REF" ]; then \

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -50,7 +50,7 @@ jobs:
                      libboost-context-dev \
                      libboost-regex-dev \
                      libboost-coroutine-dev
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         submodules: recursive
@@ -74,7 +74,7 @@ jobs:
     - run: |
         echo "OS_VERSION=`lsb_release -sr`" >> $GITHUB_ENV
     - name: Load Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ccache

--- a/include/fc/safe.hpp
+++ b/include/fc/safe.hpp
@@ -32,49 +32,70 @@ namespace fc {
       // Both T and V are signed
       template< typename V, typename... Dummy, typename X = T,
                 std::enable_if_t< std::is_signed<X>::value, bool > = true,
+                std::enable_if_t< std::is_integral<V>::value, bool > = true,
                 std::enable_if_t< std::is_signed<V>::value, bool > = true >
-      safe( V v ) : value(v)
+      static T check( V v )
       {
          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
          if( v > std::numeric_limits<T>::max() )
             FC_CAPTURE_AND_THROW( overflow_exception, (v) );
          if( v < std::numeric_limits<T>::min() )
             FC_CAPTURE_AND_THROW( underflow_exception, (v) );
+         return static_cast<T>( v );
       }
 
       // Both T and V are unsigned
       template< typename V, typename... Dummy, typename X = T,
                 std::enable_if_t< std::is_unsigned<X>::value, bool > = true,
+                std::enable_if_t< std::is_integral<V>::value, bool > = true,
                 std::enable_if_t< std::is_unsigned<V>::value, bool > = true >
-      safe( V v ) : value(v)
+      static T check( V v )
       {
          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
          if( v > std::numeric_limits<T>::max() )
             FC_CAPTURE_AND_THROW( overflow_exception, (v) );
+         return static_cast<T>( v );
       }
 
       // T is unsigned and V is signed
       template< typename V, typename... Dummy, typename X = T,
                 std::enable_if_t< std::is_unsigned<X>::value, bool > = true,
+                std::enable_if_t< std::is_integral<V>::value, bool > = true,
                 std::enable_if_t< std::is_signed<V>::value, bool > = true >
-      safe( V v ) : value(v)
+      static T check( V v )
       {
          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
          if( v < 0 )
             FC_CAPTURE_AND_THROW( underflow_exception, (v) );
          if( static_cast< typename std::make_unsigned_t<V> >(v) > std::numeric_limits<T>::max() )
             FC_CAPTURE_AND_THROW( overflow_exception, (v) );
+         return static_cast<T>( v );
       }
 
       // T is signed and V is unsigned
       template< typename V, typename... Dummy, typename X = T,
                 std::enable_if_t< std::is_signed<X>::value, bool > = true,
-                std::enable_if_t< std::is_unsigned<V>::value, bool > = 0 >
-      safe( V v ) : value(v)
+                std::enable_if_t< std::is_integral<V>::value, bool > = true,
+                std::enable_if_t< std::is_unsigned<V>::value, bool > = true >
+      static T check( V v )
       {
          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
          if( v > static_cast< typename std::make_unsigned_t<T> >( std::numeric_limits<T>::max() ) )
             FC_CAPTURE_AND_THROW( overflow_exception, (v) );
+         return static_cast<T>( v );
+      }
+
+      template< typename V >
+      safe( V v ) : value( check(v) )
+      {
+         // Nothing else to do
+      }
+
+      template< typename V >
+      safe& operator = ( V v )
+      {
+         value = check(v);
+         return *this;
       }
 
       static constexpr safe min()

--- a/include/fc/safe.hpp
+++ b/include/fc/safe.hpp
@@ -271,11 +271,11 @@ namespace fc {
       {
           return a.value == b.value;
       }
-      friend bool operator == ( const safe& a, const T& b )
+      friend bool operator == ( const safe& a, T b )
       {
           return a.value == b;
       }
-      friend bool operator == ( const T& a, const safe& b )
+      friend bool operator == ( T a, const safe& b )
       {
           return a == b.value;
       }
@@ -284,11 +284,11 @@ namespace fc {
       {
           return a.value < b.value;
       }
-      friend bool operator < ( const safe& a, const T& b )
+      friend bool operator < ( const safe& a, T b )
       {
           return a.value < b;
       }
-      friend bool operator < ( const T& a, const safe& b )
+      friend bool operator < ( T a, const safe& b )
       {
           return a < b.value;
       }
@@ -297,11 +297,11 @@ namespace fc {
       {
           return a.value > b.value;
       }
-      friend bool operator > ( const safe& a, const T& b )
+      friend bool operator > ( const safe& a, T b )
       {
           return a.value > b;
       }
-      friend bool operator > ( const T& a, const safe& b )
+      friend bool operator > ( T a, const safe& b )
       {
           return a > b.value;
       }
@@ -310,11 +310,11 @@ namespace fc {
       {
           return !(a == b);
       }
-      friend bool operator != ( const safe& a, const T& b )
+      friend bool operator != ( const safe& a, T b )
       {
           return !(a == b);
       }
-      friend bool operator != ( const T& a, const safe& b )
+      friend bool operator != ( T a, const safe& b )
       {
           return !(a == b);
       }
@@ -323,11 +323,11 @@ namespace fc {
       {
           return !(a > b);
       }
-      friend bool operator <= ( const safe& a, const T& b )
+      friend bool operator <= ( const safe& a, T b )
       {
           return !(a > b);
       }
-      friend bool operator <= ( const T& a, const safe& b )
+      friend bool operator <= ( T a, const safe& b )
       {
           return !(a > b);
       }
@@ -336,11 +336,11 @@ namespace fc {
       {
           return !(a < b);
       }
-      friend bool operator >= ( const safe& a, const T& b )
+      friend bool operator >= ( const safe& a, T b )
       {
           return !(a < b);
       }
-      friend bool operator >= ( const T& a, const safe& b )
+      friend bool operator >= ( T a, const safe& b )
       {
           return !(a < b);
       }

--- a/include/fc/safe.hpp
+++ b/include/fc/safe.hpp
@@ -6,6 +6,12 @@
 
 namespace fc {
 
+   template< typename T, std::enable_if_t< std::is_integral<T>::value, bool > = true >
+   struct safe_base
+   {
+      // Nothing here
+   };
+
    /**
     *  This type is designed to provide automatic checks for
     *  integer overflow and default initialization. It will
@@ -17,14 +23,59 @@ namespace fc {
     *  https://www.securecoding.cert.org/confluence/display/c/INT32-C.+Ensure+that+operations+on+signed+integers+do+not+result+in+overflow
     */
    template<typename T>
-   struct safe
+   struct safe : safe_base<T>
    {
       T value = 0;
 
-      template<typename O>
-      safe( O o ):value(o){}
-      safe(){}
-      safe( const safe& o ):value(o.value){}
+      safe() = default;
+
+      // Both T and V are signed
+      template< typename V, typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_signed<X>::value, bool > = true,
+                std::enable_if_t< std::is_signed<V>::value, bool > = true >
+      safe( V v ) : value(v)
+      {
+         static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
+         if( v > std::numeric_limits<T>::max() )
+            FC_CAPTURE_AND_THROW( overflow_exception, (v) );
+         if( v < std::numeric_limits<T>::min() )
+            FC_CAPTURE_AND_THROW( underflow_exception, (v) );
+      }
+
+      // Both T and V are unsigned
+      template< typename V, typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_unsigned<X>::value, bool > = true,
+                std::enable_if_t< std::is_unsigned<V>::value, bool > = true >
+      safe( V v ) : value(v)
+      {
+         static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
+         if( v > std::numeric_limits<T>::max() )
+            FC_CAPTURE_AND_THROW( overflow_exception, (v) );
+      }
+
+      // T is unsigned and V is signed
+      template< typename V, typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_unsigned<X>::value, bool > = true,
+                std::enable_if_t< std::is_signed<V>::value, bool > = true >
+      safe( V v ) : value(v)
+      {
+         static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
+         if( v < 0 )
+            FC_CAPTURE_AND_THROW( underflow_exception, (v) );
+         if( static_cast< typename std::make_unsigned_t<V> >(v) > std::numeric_limits<T>::max() )
+            FC_CAPTURE_AND_THROW( overflow_exception, (v) );
+      }
+
+      // T is signed and V is unsigned
+      template< typename V, typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_signed<X>::value, bool > = true,
+                std::enable_if_t< std::is_unsigned<V>::value, bool > = 0 >
+      safe( V v ) : value(v)
+      {
+         static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
+         if( v > static_cast< typename std::make_unsigned_t<T> >( std::numeric_limits<T>::max() ) )
+            FC_CAPTURE_AND_THROW( overflow_exception, (v) );
+      }
 
       static constexpr safe min()
       {
@@ -37,14 +88,18 @@ namespace fc {
 
       friend safe operator + ( const safe& a, const safe& b )
       {
-          if( b.value > 0 && a.value > (std::numeric_limits<T>::max() - b.value) ) FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
-          if( b.value < 0 && a.value < (std::numeric_limits<T>::min() - b.value) ) FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
+          if( b.value > 0 && a.value > (std::numeric_limits<T>::max() - b.value) )
+             FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
+          if( b.value < 0 && a.value < (std::numeric_limits<T>::min() - b.value) )
+             FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
           return safe( a.value + b.value );
       }
       friend safe operator - ( const safe& a, const safe& b )
       {
-          if( b.value > 0 && a.value < (std::numeric_limits<T>::min() + b.value) ) FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
-          if( b.value < 0 && a.value > (std::numeric_limits<T>::max() + b.value) ) FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
+          if( b.value > 0 && a.value < (std::numeric_limits<T>::min() + b.value) )
+             FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
+          if( b.value < 0 && a.value > (std::numeric_limits<T>::max() + b.value) )
+             FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
           return safe( a.value - b.value );
       }
 
@@ -54,45 +109,91 @@ namespace fc {
           {
               if( b.value > 0 )
               {
-                  if( a.value > (std::numeric_limits<T>::max() / b.value) ) FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
+                  if( a.value > (std::numeric_limits<T>::max() / b.value) )
+                     FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
               }
               else
               {
-                  if( b.value < (std::numeric_limits<T>::min() / a.value) ) FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
+                  if( b.value < (std::numeric_limits<T>::min() / a.value) )
+                     FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
               }
           }
           else
           {
               if( b.value > 0 )
               {
-                  if( a.value < (std::numeric_limits<T>::min() / b.value) ) FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
+                  if( a.value < (std::numeric_limits<T>::min() / b.value) )
+                     FC_CAPTURE_AND_THROW( underflow_exception, (a)(b) );
               }
               else
               {
-                  if( a.value != 0 && b.value < (std::numeric_limits<T>::max() / a.value) ) FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
+                  if( a.value != 0 && b.value < (std::numeric_limits<T>::max() / a.value) )
+                     FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
               }
           }
 
           return safe( a.value * b.value );
       }
 
+      // T is signed
+      template< typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_signed<X>::value, bool > = true >
       friend safe operator / ( const safe& a, const safe& b )
       {
+          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
           if( b.value == 0 ) FC_CAPTURE_AND_THROW( divide_by_zero_exception, (a)(b) );
-          if( a.value == std::numeric_limits<T>::min() && b.value == -1 ) FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
+          if( a.value == std::numeric_limits<T>::min() && b.value == -1 )
+             FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
           return safe( a.value / b.value );
       }
+      // T is unsigned
+      template< typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_unsigned<X>::value, bool > = true >
+      friend safe operator / ( const safe& a, const safe& b )
+      {
+          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
+          if( b.value == 0 ) FC_CAPTURE_AND_THROW( divide_by_zero_exception, (a)(b) );
+          return safe( a.value / b.value );
+      }
+
+      // T is signed
+      template< typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_signed<X>::value, bool > = true >
       friend safe operator % ( const safe& a, const safe& b )
       {
+          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
           if( b.value == 0 ) FC_CAPTURE_AND_THROW( divide_by_zero_exception, (a)(b) );
-          if( a.value == std::numeric_limits<T>::min() && b.value == -1 ) FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
+          if( a.value == std::numeric_limits<T>::min() && b.value == -1 )
+             FC_CAPTURE_AND_THROW( overflow_exception, (a)(b) );
+          return safe( a.value % b.value );
+      }
+      // T is unsigned
+      template< typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_unsigned<X>::value, bool > = true >
+      friend safe operator % ( const safe& a, const safe& b )
+      {
+          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
+          if( b.value == 0 ) FC_CAPTURE_AND_THROW( divide_by_zero_exception, (a)(b) );
           return safe( a.value % b.value );
       }
 
+      // T is signed
+      template< typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_signed<X>::value, bool > = true >
       safe operator - ()const
       {
+          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
           if( value == min() ) FC_CAPTURE_AND_THROW( overflow_exception, (*this) );
           return safe( -value );
+      }
+      // T is unsigned
+      template< typename... Dummy, typename X = T,
+                std::enable_if_t< std::is_unsigned<X>::value, bool > = true >
+      safe operator - ()const
+      {
+          static_assert( 0 == sizeof...(Dummy), "Unexpected template argument(s)" );
+          if( value != 0 ) FC_CAPTURE_AND_THROW( underflow_exception, (*this) );
+          return safe( 0 );
       }
 
       safe& operator += ( const safe& b )

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,4 +19,9 @@ sonar.tests=tests
 sonar.exclusions=vendor/**/*,tests/**/*
 sonar.sources=src,include
 sonar.cfamily.build-wrapper-output=bw-output
-sonar.cfamily.gcov.reportsPath=.
+
+# Note:
+# It is hard to get the gcov sensor working, but gcovr works.
+# See https://community.sonarsource.com/t/code-coverage-incorrect-for-c-gcov-project/41837/5
+#sonar.cfamily.gcov.reportsPath=.
+sonar.coverageReportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,11 +11,12 @@ sonar.links.ci=https://github.com/bitshares/bitshares-fc/actions
 sonar.links.issue=https://github.com/bitshares/bitshares-core/issues
 sonar.links.scm=https://github.com/bitshares/bitshares-fc/tree/master
 
+# Note:
+# According to docs, sonar.tests is ignored by the C/C++/Objective-C analyzer.
+# See https://docs.sonarcloud.io/advanced-setup/languages/c-c-objective-c/#language-specific-properties
 sonar.tests=tests
+
 sonar.exclusions=vendor/**/*,tests/**/*
 sonar.sources=src,include
 sonar.cfamily.build-wrapper-output=bw-output
 sonar.cfamily.gcov.reportsPath=.
-sonar.cfamily.threads=2
-sonar.cfamily.cache.enabled=true
-sonar.cfamily.cache.path=sonar_cache

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable( all_tests all_tests.cpp
                           thread/parallel_tests.cpp
                           bloom_test.cpp
                           reflection_tests.cpp
+                          safe_tests.cpp
                           serialization_test.cpp
                           stacktrace_test.cpp
                           time_test.cpp

--- a/tests/logging_tests.cpp
+++ b/tests/logging_tests.cpp
@@ -23,7 +23,9 @@ BOOST_AUTO_TEST_CASE(log_reboot)
 {
     BOOST_TEST_MESSAGE("Setting up logger");
     fc::file_appender::config conf;
-    conf.filename = "/tmp/my.log";
+    fc::temp_directory log_dir;
+    conf.filename = log_dir.path() / "my.log";
+    BOOST_TEST_MESSAGE( std::string( "conf.filename=" ) + conf.filename.string() );
     conf.format = "${timestamp} ${thread_name} ${context} ${file}:${line} ${method} ${level}]  ${message}";
     conf.flush = true;
     conf.rotate = true;

--- a/tests/safe_tests.cpp
+++ b/tests/safe_tests.cpp
@@ -21,10 +21,14 @@ BOOST_AUTO_TEST_CASE(safe_test)
     BOOST_CHECK_THROW( safe<int8_t>( -129 ), fc::underflow_exception );
     BOOST_CHECK_THROW( safe<int8_t>( int16_t(-129) ), fc::underflow_exception );
 
+    BOOST_CHECK_EQUAL( safe<int8_t>( uint16_t(127) ).value, 127 );
+
     BOOST_CHECK_THROW( safe<int8_t>( uint16_t(128) ), fc::overflow_exception );
 
     BOOST_CHECK_THROW( safe<uint16_t>( -1 ), fc::underflow_exception );
     BOOST_CHECK_THROW( safe<uint16_t>( int16_t(-1) ), fc::underflow_exception );
+
+    BOOST_CHECK_EQUAL( safe<uint8_t>( uint16_t(255) ).value, 255U );
 
     BOOST_CHECK_THROW( safe<uint8_t>( int16_t(256) ), fc::overflow_exception );
     BOOST_CHECK_THROW( safe<uint8_t>( uint16_t(256) ), fc::overflow_exception );
@@ -64,6 +68,12 @@ BOOST_AUTO_TEST_CASE(safe_test)
     BOOST_CHECK( safe<int8_t>( -2 ) * safe<int8_t>( 64 ) == -128 );
     BOOST_CHECK( safe<int8_t>( 2 ) * safe<int8_t>( -64 ) == -128 );
 
+    BOOST_CHECK( safe<int8_t>( 0 ) * safe<int8_t>( 0 ) == 0 );
+    BOOST_CHECK( safe<int8_t>( 0 ) * safe<int8_t>( 127 ) == 0 );
+    BOOST_CHECK( safe<int8_t>( 0 ) * safe<int8_t>( -128 ) == 0 );
+    BOOST_CHECK( safe<int8_t>( 127 ) * safe<int8_t>( 0 ) == 0 );
+    BOOST_CHECK( safe<int8_t>( -128 ) * safe<int8_t>( 0 ) == 0 );
+
     BOOST_CHECK_THROW( safe<int8_t>( 100 ) * 2, fc::overflow_exception );
     BOOST_CHECK_THROW( 2 * safe<int8_t>( 100 ), fc::overflow_exception );
     BOOST_CHECK_THROW( safe<int8_t>( 2 ) * safe<int8_t>( 100 ), fc::overflow_exception );
@@ -89,11 +99,19 @@ BOOST_AUTO_TEST_CASE(safe_test)
     BOOST_CHECK( safe<int8_t>( 100 ) / safe<int8_t>( -11 ) == 100 / (-11) );
     BOOST_CHECK( safe<int8_t>( -100 ) / safe<int8_t>( 11 ) == (-100) / 11 );
 
+    BOOST_CHECK( safe<int8_t>( -127 ) / safe<int8_t>( -1 ) == (-127) / (-1) );
+    BOOST_CHECK( safe<int8_t>( -128 ) / safe<int8_t>( -3 ) == (-128) / (-3) );
+
+    BOOST_CHECK_THROW( safe<int8_t>( 0 ) / safe<int8_t>( 0 ), fc::divide_by_zero_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( 127 ) / safe<int8_t>( 0 ), fc::divide_by_zero_exception );
     BOOST_CHECK_THROW( safe<int8_t>( -128 ) / safe<int8_t>( 0 ), fc::divide_by_zero_exception );
+
     BOOST_CHECK_THROW( safe<int8_t>( -128 ) / safe<int8_t>( -1 ), fc::overflow_exception );
 
     BOOST_CHECK( safe<uint8_t>( 100 ) / safe<uint8_t>( 11 ) == 100U / 11U );
+    BOOST_CHECK( safe<uint8_t>( 0 ) / safe<uint8_t>( 255 ) == 0U );
 
+    BOOST_CHECK_THROW( safe<uint8_t>( 0 ) / safe<uint8_t>( 0 ), fc::divide_by_zero_exception );
     BOOST_CHECK_THROW( safe<uint8_t>( 128 ) / safe<uint8_t>( 0 ), fc::divide_by_zero_exception );
 
     BOOST_CHECK( safe<int8_t>( 100 ) % safe<int8_t>( 11 ) == 100 % 11 );
@@ -101,11 +119,19 @@ BOOST_AUTO_TEST_CASE(safe_test)
     BOOST_CHECK( safe<int8_t>( 100 ) % safe<int8_t>( -11 ) == 100 % (-11) );
     BOOST_CHECK( safe<int8_t>( -100 ) % safe<int8_t>( 11 ) == (-100) % 11 );
 
+    BOOST_CHECK( safe<int8_t>( -127 ) % safe<int8_t>( -1 ) == (-127) % (-1) );
+    BOOST_CHECK( safe<int8_t>( -128 ) % safe<int8_t>( -3 ) == (-128) % (-3) );
+
+    BOOST_CHECK_THROW( safe<int8_t>( 0 ) % safe<int8_t>( 0 ), fc::divide_by_zero_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( 127 ) % safe<int8_t>( 0 ), fc::divide_by_zero_exception );
     BOOST_CHECK_THROW( safe<int8_t>( -128 ) % safe<int8_t>( 0 ), fc::divide_by_zero_exception );
+
     BOOST_CHECK_THROW( safe<int8_t>( -128 ) % safe<int8_t>( -1 ), fc::overflow_exception );
 
     BOOST_CHECK( safe<uint8_t>( 100 ) % safe<uint8_t>( 11 ) == 100U % 11U );
+    BOOST_CHECK( safe<uint8_t>( 0 ) % safe<uint8_t>( 255 ) == 0U );
 
+    BOOST_CHECK_THROW( safe<uint8_t>( 0 ) % safe<uint8_t>( 0 ), fc::divide_by_zero_exception );
     BOOST_CHECK_THROW( safe<uint8_t>( 128 ) % safe<uint8_t>( 0 ), fc::divide_by_zero_exception );
 
     BOOST_CHECK( -100 == -safe<int8_t>( 100 ) );
@@ -148,6 +174,7 @@ BOOST_AUTO_TEST_CASE(safe_test)
     BOOST_CHECK_THROW( ++si, fc::overflow_exception );
     BOOST_CHECK_THROW( si*=2, fc::overflow_exception );
     BOOST_CHECK_THROW( si*=(-2), fc::underflow_exception );
+    BOOST_CHECK_EQUAL( si.value, 127 );
 
     si = -128;
 
@@ -159,6 +186,48 @@ BOOST_AUTO_TEST_CASE(safe_test)
     BOOST_CHECK_THROW( si%=(-1), fc::overflow_exception );
     BOOST_CHECK_THROW( si/=(0), fc::divide_by_zero_exception );
     BOOST_CHECK_THROW( si%=(0), fc::divide_by_zero_exception );
+    BOOST_CHECK_EQUAL( si.value, -128 );
+
+    safe<uint8_t> su = 0;
+
+    BOOST_CHECK( (su+=1) == 1U );
+    BOOST_CHECK_EQUAL( su.value, 1U );
+    BOOST_CHECK( (++su) == 2U );
+    BOOST_CHECK_EQUAL( su.value, 2U );
+    BOOST_CHECK( (su++) == 2U );
+    BOOST_CHECK_EQUAL( su.value, 3U );
+
+    BOOST_CHECK( (su*=5) == 15U );
+    BOOST_CHECK_EQUAL( su.value, 15U );
+
+    BOOST_CHECK( (su/=2) == 7U );
+    BOOST_CHECK_EQUAL( su.value, 7U );
+
+    BOOST_CHECK( (su%=4) == 3U );
+    BOOST_CHECK_EQUAL( su.value, 3U );
+
+    BOOST_CHECK( (su-=1) == 2U );
+    BOOST_CHECK_EQUAL( su.value, 2U );
+    BOOST_CHECK( (--su) == 1U );
+    BOOST_CHECK_EQUAL( su.value, 1 );
+    BOOST_CHECK( (su--) == 1U );
+    BOOST_CHECK_EQUAL( su.value, 0U );
+
+    BOOST_CHECK_THROW( su-=1, fc::underflow_exception );
+    BOOST_CHECK_THROW( su--, fc::underflow_exception );
+    BOOST_CHECK_THROW( --su, fc::underflow_exception );
+    BOOST_CHECK_EQUAL( su.value, 0U );
+
+    su = 255;
+
+    BOOST_CHECK_THROW( su+=1, fc::overflow_exception );
+    BOOST_CHECK_THROW( su++, fc::overflow_exception );
+    BOOST_CHECK_THROW( ++su, fc::overflow_exception );
+    BOOST_CHECK_THROW( su*=2, fc::overflow_exception );
+    BOOST_CHECK_THROW( su*=(-2), fc::underflow_exception );
+    BOOST_CHECK_THROW( su/=(0), fc::divide_by_zero_exception );
+    BOOST_CHECK_THROW( su%=(0), fc::divide_by_zero_exception );
+    BOOST_CHECK_EQUAL( su.value, 255U );
 
     BOOST_CHECK( safe<int8_t>( 1 ) != safe<int8_t>( 2 ) );
     BOOST_CHECK( 1 != safe<int8_t>( 2 ) );

--- a/tests/safe_tests.cpp
+++ b/tests/safe_tests.cpp
@@ -1,0 +1,185 @@
+#include <boost/test/unit_test.hpp>
+#include <fc/safe.hpp>
+
+using namespace fc;
+
+BOOST_AUTO_TEST_SUITE(fc)
+
+BOOST_AUTO_TEST_CASE(safe_test)
+{
+
+    BOOST_CHECK_EQUAL( safe<int8_t>( -128 ).value, -128 );
+    BOOST_CHECK_EQUAL( safe<int8_t>( 0 ).value, 0 );
+    BOOST_CHECK_EQUAL( safe<int8_t>( 127 ).value, 127 );
+
+    BOOST_CHECK_EQUAL( safe<uint8_t>( 0 ).value, 0U );
+    BOOST_CHECK_EQUAL( safe<uint8_t>( 255 ).value, 255U );
+
+    BOOST_CHECK_THROW( safe<int8_t>( 128 ), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( int16_t(128) ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -129 ), fc::underflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( int16_t(-129) ), fc::underflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( uint16_t(128) ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<uint16_t>( -1 ), fc::underflow_exception );
+    BOOST_CHECK_THROW( safe<uint16_t>( int16_t(-1) ), fc::underflow_exception );
+
+    BOOST_CHECK_THROW( safe<uint8_t>( int16_t(256) ), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<uint8_t>( uint16_t(256) ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<uint16_t>( uint32_t(-1) ), fc::overflow_exception );
+
+    BOOST_CHECK_EQUAL( safe<int8_t>::min().value, -128 );
+    BOOST_CHECK_EQUAL( safe<int8_t>::max().value, 127 );
+
+    BOOST_CHECK_EQUAL( safe<uint8_t>::min().value, 0U );
+    BOOST_CHECK_EQUAL( safe<uint8_t>::max().value, 255U );
+
+    BOOST_CHECK( safe<int8_t>( 100 ) + safe<int8_t>( 27 ) == 127 );
+    BOOST_CHECK( safe<int8_t>( -100 ) + safe<int8_t>( -28 ) == -128 );
+
+    BOOST_CHECK_THROW( safe<int8_t>( 100 ) + safe<int8_t>( 28 ), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( 100 ) + 28, fc::overflow_exception );
+    BOOST_CHECK_THROW( 100 + safe<int8_t>( 28 ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -100 ) + safe<int8_t>( -29 ), fc::underflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -100 ) + (-29), fc::underflow_exception );
+    BOOST_CHECK_THROW( (-100) + safe<int8_t>( -29 ), fc::underflow_exception );
+
+    BOOST_CHECK( safe<int8_t>( 100 ) - safe<int8_t>( -27 ) == 127 );
+    BOOST_CHECK( safe<int8_t>( -100 ) - safe<int8_t>( 28 ) == -128 );
+
+    BOOST_CHECK_THROW( safe<int8_t>( 100 ) - safe<int8_t>( -28 ), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( 100 ) - (-28), fc::overflow_exception );
+    BOOST_CHECK_THROW( 100 - safe<int8_t>( -28 ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -100 ) - safe<int8_t>( 29 ), fc::underflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -100 ) - 29, fc::underflow_exception );
+    BOOST_CHECK_THROW( (-100) - safe<int8_t>( 29 ), fc::underflow_exception );
+
+    BOOST_CHECK( safe<int8_t>( 10 ) * safe<int8_t>( 11 ) == 110 );
+    BOOST_CHECK( safe<int8_t>( -10 ) * safe<int8_t>( -11 ) == 110 );
+    BOOST_CHECK( safe<int8_t>( -2 ) * safe<int8_t>( 64 ) == -128 );
+    BOOST_CHECK( safe<int8_t>( 2 ) * safe<int8_t>( -64 ) == -128 );
+
+    BOOST_CHECK_THROW( safe<int8_t>( 100 ) * 2, fc::overflow_exception );
+    BOOST_CHECK_THROW( 2 * safe<int8_t>( 100 ), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( 2 ) * safe<int8_t>( 100 ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( 100 ) * (-2), fc::underflow_exception );
+    BOOST_CHECK_THROW( 2 * safe<int8_t>( -100 ), fc::underflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( 2 ) * safe<int8_t>( -100 ), fc::underflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -100 ) * (-2), fc::overflow_exception );
+    BOOST_CHECK_THROW( (-2) * safe<int8_t>( -100 ), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -2 ) * safe<int8_t>( -100 ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -128 ) * (-1), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -1 ) * (-128), fc::overflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -1 ) * safe<int8_t>( -128 ), fc::overflow_exception );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -100 ) * 2, fc::underflow_exception );
+    BOOST_CHECK_THROW( (-2) * safe<int8_t>( 100 ), fc::underflow_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -2 ) * safe<int8_t>( 100 ), fc::underflow_exception );
+
+    BOOST_CHECK( safe<int8_t>( 100 ) / safe<int8_t>( 11 ) == 100 / 11 );
+    BOOST_CHECK( safe<int8_t>( -100 ) / safe<int8_t>( -11 ) == (-100) / (-11) );
+    BOOST_CHECK( safe<int8_t>( 100 ) / safe<int8_t>( -11 ) == 100 / (-11) );
+    BOOST_CHECK( safe<int8_t>( -100 ) / safe<int8_t>( 11 ) == (-100) / 11 );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -128 ) / safe<int8_t>( 0 ), fc::divide_by_zero_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -128 ) / safe<int8_t>( -1 ), fc::overflow_exception );
+
+    BOOST_CHECK( safe<uint8_t>( 100 ) / safe<uint8_t>( 11 ) == 100U / 11U );
+
+    BOOST_CHECK_THROW( safe<uint8_t>( 128 ) / safe<uint8_t>( 0 ), fc::divide_by_zero_exception );
+
+    BOOST_CHECK( safe<int8_t>( 100 ) % safe<int8_t>( 11 ) == 100 % 11 );
+    BOOST_CHECK( safe<int8_t>( -100 ) % safe<int8_t>( -11 ) == (-100) % (-11) );
+    BOOST_CHECK( safe<int8_t>( 100 ) % safe<int8_t>( -11 ) == 100 % (-11) );
+    BOOST_CHECK( safe<int8_t>( -100 ) % safe<int8_t>( 11 ) == (-100) % 11 );
+
+    BOOST_CHECK_THROW( safe<int8_t>( -128 ) % safe<int8_t>( 0 ), fc::divide_by_zero_exception );
+    BOOST_CHECK_THROW( safe<int8_t>( -128 ) % safe<int8_t>( -1 ), fc::overflow_exception );
+
+    BOOST_CHECK( safe<uint8_t>( 100 ) % safe<uint8_t>( 11 ) == 100U % 11U );
+
+    BOOST_CHECK_THROW( safe<uint8_t>( 128 ) % safe<uint8_t>( 0 ), fc::divide_by_zero_exception );
+
+    BOOST_CHECK( -100 == -safe<int8_t>( 100 ) );
+    BOOST_CHECK( safe<int8_t>( 0 ) == -safe<int8_t>( 0 ) );
+    BOOST_CHECK( 100 == -safe<int8_t>( -100 ) );
+    BOOST_CHECK_THROW( -safe<int8_t>( -128 ), fc::overflow_exception );
+
+    BOOST_CHECK( safe<uint8_t>( 0 ) == -safe<uint8_t>( 0 ) );
+    BOOST_CHECK_THROW( -safe<uint8_t>( 1 ), fc::underflow_exception );
+
+    safe<int8_t> si = 0;
+
+    BOOST_CHECK( (si+=1) == 1 );
+    BOOST_CHECK_EQUAL( si.value, 1 );
+    BOOST_CHECK( (++si) == 2 );
+    BOOST_CHECK_EQUAL( si.value, 2 );
+    BOOST_CHECK( (si++) == 2 );
+    BOOST_CHECK_EQUAL( si.value, 3 );
+
+    BOOST_CHECK( (si*=5) == 15 );
+    BOOST_CHECK_EQUAL( si.value, 15 );
+
+    BOOST_CHECK( (si/=2) == 7 );
+    BOOST_CHECK_EQUAL( si.value, 7 );
+
+    BOOST_CHECK( (si%=4) == 3 );
+    BOOST_CHECK_EQUAL( si.value, 3 );
+
+    BOOST_CHECK( (si-=1) == 2 );
+    BOOST_CHECK_EQUAL( si.value, 2 );
+    BOOST_CHECK( (--si) == 1 );
+    BOOST_CHECK_EQUAL( si.value, 1 );
+    BOOST_CHECK( (si--) == 1 );
+    BOOST_CHECK_EQUAL( si.value, 0 );
+
+    si = 127;
+
+    BOOST_CHECK_THROW( si+=1, fc::overflow_exception );
+    BOOST_CHECK_THROW( si++, fc::overflow_exception );
+    BOOST_CHECK_THROW( ++si, fc::overflow_exception );
+    BOOST_CHECK_THROW( si*=2, fc::overflow_exception );
+    BOOST_CHECK_THROW( si*=(-2), fc::underflow_exception );
+
+    si = -128;
+
+    BOOST_CHECK_THROW( si-=1, fc::underflow_exception );
+    BOOST_CHECK_THROW( si--, fc::underflow_exception );
+    BOOST_CHECK_THROW( --si, fc::underflow_exception );
+    BOOST_CHECK_THROW( si*=(-1), fc::overflow_exception );
+    BOOST_CHECK_THROW( si/=(-1), fc::overflow_exception );
+    BOOST_CHECK_THROW( si%=(-1), fc::overflow_exception );
+    BOOST_CHECK_THROW( si/=(0), fc::divide_by_zero_exception );
+    BOOST_CHECK_THROW( si%=(0), fc::divide_by_zero_exception );
+
+    BOOST_CHECK( safe<int8_t>( 1 ) != safe<int8_t>( 2 ) );
+    BOOST_CHECK( 1 != safe<int8_t>( 2 ) );
+    BOOST_CHECK( safe<int8_t>( 1 ) != 2 );
+
+    BOOST_CHECK( safe<int8_t>( 1 ) <= safe<int8_t>( 2 ) );
+    BOOST_CHECK( 1 <= safe<int8_t>( 2 ) );
+    BOOST_CHECK( safe<int8_t>( 1 ) <= 2 );
+
+    BOOST_CHECK( safe<int8_t>( 1 ) < safe<int8_t>( 2 ) );
+    BOOST_CHECK( 1 < safe<int8_t>( 2 ) );
+    BOOST_CHECK( safe<int8_t>( 1 ) < 2 );
+
+    BOOST_CHECK( safe<int8_t>( 3 ) >= safe<int8_t>( 2 ) );
+    BOOST_CHECK( 3 >= safe<int8_t>( 2 ) );
+    BOOST_CHECK( safe<int8_t>( 3 ) >= 2 );
+
+    BOOST_CHECK( safe<int8_t>( 3 ) > safe<int8_t>( 2 ) );
+    BOOST_CHECK( 3 > safe<int8_t>( 2 ) );
+    BOOST_CHECK( safe<int8_t>( 3 ) > 2 );
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
PR for https://github.com/bitshares/bitshares-core/issues/2147.

* Improve `safe<T>`
  * support only integers, both signed and unsigned
  * check overflow and underflow on initialization
  * fix issues when T is unsigned
  * add tests
  * remove explicitly declared copy constructor, so that the compiler will implicitly declare copy constructors, move constructors, assignment operators, etc
* Fix a cleanup issue in logging_tests
* Update some CI configurations
  * Bump versions of actions/checkout and actions/cache to `v3`
  * Stop using Ubuntu 18
  * Run sonar-scan workflow with Ubuntu 20 instead of `ubuntu-latest` which is now Ubuntu 22
  * Run macOS workflow with OpenSSL 1.1
  * Address https://github.com/bitshares/bitshares-core/issues/2738
  * Use `gcovr` to process code coverage data for better coverage reporting, including branch coverage