### PR TITLE
Rethrow asio operation cancellation exception as `fc::canceled_exception`

### DIFF
--- a/src/asio.cpp
+++ b/src/asio.cpp
@@ -53,13 +53,21 @@ namespace fc {
             {
                 if( ec == boost::asio::error::eof  )
                 {
-                  p->set_exception( fc::exception_ptr( new fc::eof_exception(
-                          FC_LOG_MESSAGE( error, "${message} ", ("message", boost::system::system_error(ec).what())) ) ) );
+                  p->set_exception( std::make_shared<fc::eof_exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
+                }
+                else if( ec == boost::asio::error::operation_aborted )
+                {
+                  p->set_exception( std::make_shared<fc::canceled_exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
                 }
                 else
                 {
-                  p->set_exception( fc::exception_ptr( new fc::exception(
-                          FC_LOG_MESSAGE( error, "${message} ", ("message", boost::system::system_error(ec).what())) ) ) );
+                  p->set_exception( std::make_shared<fc::exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
                 }
             }
         }


### PR DESCRIPTION
Rethrow asio operation cancellation exception `boost::asio::error::operation_aborted` as `fc::canceled_exception` instead of `fc::exception` to fix errors like below.

>`p2p:connect_to_task           connect_to ] Failed to connect to remote endpoint x.x.x.x:x from local endpoint 0.0.0.0:x, will connect using an OS-selected endpoint: {"code":0,"name":"exception","message":"unspecified","stack":[{"context":{"level":"error","file":"asio.cpp","line":62,"method":"error_handler","hostname":"","thread_name":"fc::asio worker #1","timestamp":"x-x-xTx:x:x"},"format":"${message} ","data":{"message":"Operation canceled"}}]}`