### PR TITLE
Rethrow more asio operation cancellation exception as `fc::canceled_exception`

### DIFF
--- a/src/asio.cpp
+++ b/src/asio.cpp
@@ -22,9 +22,23 @@ namespace fc {
         if( !ec )
           _completion_promise->set_value(bytes_transferred);
         else if( ec == boost::asio::error::eof  )
-          _completion_promise->set_exception( fc::exception_ptr( new fc::eof_exception( FC_LOG_MESSAGE( error, "${message} ", ("message", boost::system::system_error(ec).what())) ) ) );
+        {
+          _completion_promise->set_exception( std::make_shared<fc::eof_exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
+        }
+        else if( ec == boost::asio::error::operation_aborted )
+        {
+          _completion_promise->set_exception( std::make_shared<fc::canceled_exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
+        }
         else
-          _completion_promise->set_exception( fc::exception_ptr( new fc::exception( FC_LOG_MESSAGE( error, "${message} ", ("message", boost::system::system_error(ec).what())) ) ) );
+        {
+          _completion_promise->set_exception( std::make_shared<fc::exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
+        }
       }
       read_write_handler_with_buffer::read_write_handler_with_buffer(const promise<size_t>::ptr& completion_promise,
                                                                      const std::shared_ptr<const char>& buffer) :
@@ -36,12 +50,27 @@ namespace fc {
         if( !ec )
           _completion_promise->set_value(bytes_transferred);
         else if( ec == boost::asio::error::eof  )
-          _completion_promise->set_exception( fc::exception_ptr( new fc::eof_exception( FC_LOG_MESSAGE( error, "${message} ", ("message", boost::system::system_error(ec).what())) ) ) );
+        {
+          _completion_promise->set_exception( std::make_shared<fc::eof_exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
+        }
+        else if( ec == boost::asio::error::operation_aborted )
+        {
+          _completion_promise->set_exception( std::make_shared<fc::canceled_exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
+        }
         else
-          _completion_promise->set_exception( fc::exception_ptr( new fc::exception( FC_LOG_MESSAGE( error, "${message} ", ("message", boost::system::system_error(ec).what())) ) ) );
+        {
+          _completion_promise->set_exception( std::make_shared<fc::exception>(
+                          FC_LOG_MESSAGE( error, "${message} ",
+                                          ("message", boost::system::system_error(ec).what())) ) );
+        }
       }
 
-        void read_write_handler_ec( promise<size_t>* p, boost::system::error_code* oec, const boost::system::error_code& ec, size_t bytes_transferred ) {
+        void read_write_handler_ec( promise<size_t>* p, boost::system::error_code* oec,
+                                    const boost::system::error_code& ec, size_t bytes_transferred ) {
             p->set_value(bytes_transferred);
             *oec = ec;
         }


### PR DESCRIPTION
Rethrow more asio operation cancellation exception `boost::asio::error::operation_aborted` as `fc::canceled_exception` instead of `fc::exception` in read/write handlers to fix errors like below.

>`p2p:connect_to_task           connect_to ] Failed to connect to remote endpoint x.x.x.x:x from local endpoint 0.0.0.0:x, will connect using an OS-selected endpoint: {"code":0,"name":"exception","message":"unspecified","stack":[{"context":{"level":"error","file":"asio.cpp","line":41,"method":"error_handler","hostname":"","thread_name":"fc::asio worker #1","timestamp":"x-x-xTx:x:x"},"format":"${message} ","data":{"message":"Operation canceled"}}]}`

See also #249.

Note that this PR and #249 essentially revert https://github.com/bitshares/bitshares-fc/commit/f8472af119fccc4737e1de4c0dbdcd233ddb6203 and a part of https://github.com/bitshares/bitshares-fc/commit/751777e754a28cf261453e5a8e91e3470270edea . The commit https://github.com/bitshares/bitshares-fc/commit/f8472af119fccc4737e1de4c0dbdcd233ddb6203 says:
> Change `fc::canceled_exception`s thrown due to a socket operation being canceled into regular `fc::exception`s -- we're reserving `canceled_exception` for canceling async tasks

But I think async task cancellation will trigger socket operation abortion, we need a `fc::calceled_exception` to handle it correctly.