### PR TITLE
Avoid potential corruption during unpack of static_variant

### DIFF
--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -889,8 +889,9 @@ namespace fc {
        --_max_depth;
        unsigned_int w;
        fc::raw::unpack( s, w, _max_depth );
-       sv.set_which(w.value);
-       sv.visit( unpack_static_variant<Stream>( s, _max_depth ) );
+       static_variant<T...> helper( static_cast<typename static_variant<T...>::tag_type>(w.value) );
+       helper.visit( unpack_static_variant<Stream>( s, _max_depth ) );
+       sv = helper;
     }
 
 } } // namespace fc::raw


### PR DESCRIPTION
Note: this is to redo #250 which was merged but reverted.

Before this change, when `sv.set_which(w.value)` is already done and the following `sv.visit(...)` throws, the `staic_variant` object passed into the function may be updated to something incomplete and may cause unintended problems.

Although usually we don't reuse `static_variant` variables, it's not guaranteed.

This does lead to additional data copy.

Reference: https://gitlab.syncad.com/hive/hive/-/merge_requests/1049

