### PR TITLE
fixed missing include cstdint in string.hpp for uint64_t

### DIFF
--- a/include/fc/string.hpp
+++ b/include/fc/string.hpp
@@ -3,6 +3,8 @@
 #include <fc/optional.hpp>
 #include <string>
 
+#include <cstdint> // for uint64_t etc
+
 namespace fc
 {
     using std::string;


### PR DESCRIPTION
Without this include, it doesn't compile on Ubuntu 24.04.1 LTS